### PR TITLE
Abstract method getName not defined

### DIFF
--- a/Form/CommentType.php
+++ b/Form/CommentType.php
@@ -27,7 +27,8 @@ class CommentType extends AbstractType
         $builder->add('body', 'textarea');
     }
 
-    public function getName() {
-        return "comment";
+    public function getName()
+    {
+        return "fos_comment_comment";
     }
 }


### PR DESCRIPTION
Due to a change in symfony API, the bundle is broken. This patch repairs it.

See: https://github.com/symfony/symfony/commit/ef022c0c6c6f8635d73862aaf58cdb9416f038cb
