### PR TITLE
delete relation to user bundle

### DIFF
--- a/Model/SignedCommentInterface.php
+++ b/Model/SignedCommentInterface.php
@@ -11,7 +11,7 @@
 
 namespace FOS\CommentBundle\Model;
 
-use FOS\UserBundle\Model\UserInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * A signed comment is bound to a FOS\UserBundle User model.


### PR DESCRIPTION
I don't see any reasons to use UserInterface from FOSUserBundle. there isn't any code which uses this interface. so I think it would be enough just restrict it to security component UserInterface.

P.S. I have problems with using FOSCommnetBundle standalone (without FOSUserBundle)
