### PR TITLE
Introduced the recommendation to use DEFERRED_EXPLICIT

### DIFF
--- a/Resources/config/doctrine/Thread.mongodb.xml
+++ b/Resources/config/doctrine/Thread.mongodb.xml
@@ -14,7 +14,7 @@
                         xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
-    <document name="FOS\CommentBundle\Document\Thread" collection="fos_comment_thread" customId="true">
+    <document name="FOS\CommentBundle\Document\Thread" collection="fos_comment_thread" customId="true" change-tracking-policy="DEFERRED_EXPLICIT">
 
         <field name="identifier" type="string" id="true" strategy="NONE" />
 

--- a/Resources/config/doctrine/Thread.orm.xml
+++ b/Resources/config/doctrine/Thread.orm.xml
@@ -14,7 +14,7 @@
                         xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                         http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <entity name="FOS\CommentBundle\Entity\Thread" table="fos_comment_thread">
+    <entity name="FOS\CommentBundle\Entity\Thread" table="fos_comment_thread" change-tracking-policy="DEFERRED_EXPLICIT">
 
         <id name="identifier" type="string" column="identifier" />
 
@@ -25,6 +25,7 @@
         <field name="numComments" column="numComments" type="integer" />
 
         <field name="lastCommentAt" column="lastCommentAt" type="datetime" nullable="true" />
+
     </entity>
 
 </doctrine-mapping>

--- a/Resources/config/doctrine/Vote.mongodb.xml
+++ b/Resources/config/doctrine/Vote.mongodb.xml
@@ -14,7 +14,7 @@
                         xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
-    <document name="FOS\CommentBundle\Document\Vote" collection="fos_comment_vote" customId="true">
+    <document name="FOS\CommentBundle\Document\Vote" collection="fos_comment_vote" customId="true" change-tracking-policy="DEFERRED_EXPLICIT>
 
         <field name="id" id="true" />
 

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -90,6 +90,9 @@ Minimal configuration
 At a minimum, your configuration must define your DB driver ("orm" or "mongodb")
 and a Comment class.
 
+We recommend that any entity that is created or used for CommentBundle uses the
+DEFERRED_EXPLICIT change tracking policy.
+
 MongoDB
 ~~~
 
@@ -105,6 +108,7 @@ you must create one::
 
     /**
      * @MongoDB\Document
+     * @MongoDB\ChangeTrackingPolicy("DEFERRED_EXPLICIT")
      */
     class Comment extends BaseComment
     {
@@ -153,6 +157,7 @@ you must create one::
 
     /**
      * @ORM\Entity
+     * @ORM\ChangeTrackingPolicy("DEFERRED_EXPLICIT")
      */
     class Comment extends BaseComment
     {
@@ -271,14 +276,15 @@ While there, make it implement SignedCommentInterface and VotableCommentInterfac
     use Bar\UserBundle\Document\User;
 
     /**
-     * @mongodb:Document()
+     * @MongoDB\Document
+     * @MongoDB\ChangeTrackingPolicy("DEFERRED_EXPLICIT")
      */
     class Comment extends BaseComment implements SignedCommentInterface, VotableCommentInterface
     {
         /**
          * Author of the comment
          *
-         * @mongodb:ReferenceOne(targetDocument="Bar\UserBundle\Document\User")
+         * @MongoDB\ReferenceOne(targetDocument="Bar\UserBundle\Document\User")
          * @var User
          */
         protected $author;
@@ -303,7 +309,7 @@ While there, make it implement SignedCommentInterface and VotableCommentInterfac
         /**
          * Comment voting score.
          *
-         * @mongodb:Field(type="int")
+         * @MongoDB\Field(type="int")
          * @var integer
          */
         protected $score;
@@ -356,7 +362,7 @@ And that's it, really.
 Enabling use of the Symfony2 Security Component
 ===============================
 
-CommentBundle comes bundled with the ability to different security features provided
+CommentBundle comes bundled with the ability to use different security features provided
 by Symfony2.
 
 Using Symfony2's Built in Acl system


### PR DESCRIPTION
The introduction means that unless the developer specifically wants
the entity manager to flush changes to CommentBundle entities, that
the flush will only occur when CommentBundle intends the flushes to
occur.

It is not necessary, but recommended due to the nature of the ORM
EntityManager flushing all changes when requested, rather than just
changes we want to be flushed.

Fixes #26
