### PR TITLE
votemanager issue

### DIFF
--- a/Entity/VoteManager.php
+++ b/Entity/VoteManager.php
@@ -62,12 +62,15 @@ class VoteManager extends BaseVoteManager
      */
     public function addVote(VoteInterface $vote, VotableCommentInterface $comment)
     {
-        $vote->setComment($comment);
-        $comment->setScore($comment->getScore() + $vote->getValue());
+        $vote->setComment($comment);        
 
         $this->em->persist($comment);
-        $this->em->persist($vote);
-        $this->em->flush();
+        $this->em->persist($vote);                
+        if(!$this->repository->findBy(array('comment'=>$comment->getId(),'voter'=>$vote->getVoter()->getId())))
+        {
+            $comment->incrementScore($vote->getvalue());
+            $this->em->flush();
+        }
     }
 
     /**


### PR DESCRIPTION
This commit is intended to discuss the following problem: how to restrict one vote per comment per user(voter)?
My solution (as for me) looks dirty, may be more experienced developers suggest a much better solution?
Also i have thoughts to make composite key (doctrine) combined from comment_id and voter_id, so a DBMS can restrict multiple votes per comment within same user.
