### PR TITLE
Pluralization (more than 4) correction to polish translation

### DIFF
--- a/Resources/translations/FOSCommentBundle.pl.yml
+++ b/Resources/translations/FOSCommentBundle.pl.yml
@@ -12,6 +12,6 @@ fos_comment_comment_show_reply:               Odpowiedz
 
 fos_comment_comment_tree_load_more:           Załaduj więcej odpowiedzi 
 
-Showing %num% comment|Showing %num% comments: Pokazuje %num% komentarz|Pokazuje %num% komentarzy
+Showing %num% comment|Showing %num% comments: Pokazuje %num% komentarz|Pokazuje %num% komentarze|Pokazuje %num% komentarzy
 
 fos_comment_rss_feed:                         RSS Feed


### PR DESCRIPTION
Third pluralization option (more than 4 comments) for translation. 
Without this options Symfony throws "Unable to choose a translation" InvalidArgumentException during rendering thread with more than 4 comments and polish locale.
