### PR TITLE
Explicitly requests html format.

### DIFF
--- a/Controller/ThreadController.php
+++ b/Controller/ThreadController.php
@@ -367,7 +367,7 @@ class ThreadController extends Controller
      */
     protected function onCreateCommentSuccess(FormInterface $form, $id, CommentInterface $parent = null)
     {
-        return RouteRedirectView::create('fos_comment_get_thread_comment', array('id' => $id, 'commentId' => $form->getData()->getId()));
+        return RouteRedirectView::create('fos_comment_get_thread_comment', array('id' => $id, 'commentId' => $form->getData()->getId(), '_format' => 'html'));
     }
 
     /**
@@ -402,7 +402,7 @@ class ThreadController extends Controller
      */
     protected function onCreateThreadSuccess(FormInterface $form)
     {
-        return RouteRedirectView::create('fos_comment_get_thread', array('id' => $form->getData()->getId()));
+        return RouteRedirectView::create('fos_comment_get_thread', array('id' => $form->getData()->getId(), '_format' => 'html'));
     }
 
     /**
@@ -448,7 +448,7 @@ class ThreadController extends Controller
      */
     protected function onCreateVoteSuccess(FormInterface $form, $id, $commentId)
     {
-        return RouteRedirectView::create('fos_comment_get_thread_comment_votes', array('id' => $id, 'commentId' => $commentId));
+        return RouteRedirectView::create('fos_comment_get_thread_comment_votes', array('id' => $id, 'commentId' => $commentId, '_format' => 'html'));
     }
 
     /**

--- a/Resources/views/Thread/async.html.twig
+++ b/Resources/views/Thread/async.html.twig
@@ -14,7 +14,7 @@
 {% javascripts '@FOSCommentBundle/Resources/assets/js/comments.js' %}
 <script type="text/javascript">
 // URI identifier for the thread comments
-var fos_comment_thread_id = '{{ path('fos_comment_get_thread_comments', {'id': id}) }}';
+var fos_comment_thread_id = '{{ path('fos_comment_get_thread_comments', {'id': id, '_format': 'html'}) }}';
 
 // Snippet for asynchronously loading the comments
 (function() {

--- a/Resources/views/Thread/comment.html.twig
+++ b/Resources/views/Thread/comment.html.twig
@@ -17,8 +17,8 @@
         {% trans from 'FOSCommentBundle' %}fos_comment_comment_show_by{% endtrans %} {{ comment.authorName }} - {{ comment.createdAt|date }}
         {% if fos_comment_can_vote(comment) %}
         <div class="fos_comment_comment_voting">
-            <button data-url="{{ url("fos_comment_new_thread_comment_votes", {"id": comment.thread.id, "commentId": comment.id, "value": 1}) }}" class="fos_comment_comment_vote">{% trans from 'FOSCommentBundle' %}fos_comment_comment_show_voteup{% endtrans %}</button>
-            <button data-url="{{ url("fos_comment_new_thread_comment_votes", {"id": comment.thread.id, "commentId": comment.id, "value": -1}) }}" class="fos_comment_comment_vote">{% trans from 'FOSCommentBundle' %}fos_comment_comment_show_votedown{% endtrans %}</button>
+            <button data-url="{{ url("fos_comment_new_thread_comment_votes", {"id": comment.thread.id, "commentId": comment.id, "value": 1, '_format': 'html'}) }}" class="fos_comment_comment_vote">{% trans from 'FOSCommentBundle' %}fos_comment_comment_show_voteup{% endtrans %}</button>
+            <button data-url="{{ url("fos_comment_new_thread_comment_votes", {"id": comment.thread.id, "commentId": comment.id, "value": -1, '_format': 'html'}) }}" class="fos_comment_comment_vote">{% trans from 'FOSCommentBundle' %}fos_comment_comment_show_votedown{% endtrans %}</button>
             <div class="fos_comment_comment_score" id="fos_comment_score_{{ comment.id }}">{% include "FOSCommentBundle:Thread:comment_votes.html.twig" with { 'commentScore': comment.score } %}</div>
         </div>
         {% endif %}
@@ -35,7 +35,7 @@
         <div class="fos_comment_comment_replies" style="margin-left: 2em;">
         {% if comment.thread.commentable and fos_comment_can_comment(comment) %}
             <div class="fos_comment_comment_reply">
-                <button data-url="{{ url('fos_comment_new_thread_comments', {"id": comment.thread.id}) }}" data-name="{{ comment.authorName }}" data-parent-id="{{ comment.id }}" class="fos_comment_comment_reply_show_form">{% trans from 'FOSCommentBundle' %}fos_comment_comment_show_reply{% endtrans %}</button>
+                <button data-url="{{ url('fos_comment_new_thread_comments', {"id": comment.thread.id, '_format': 'html'}) }}" data-name="{{ comment.authorName }}" data-parent-id="{{ comment.id }}" class="fos_comment_comment_reply_show_form">{% trans from 'FOSCommentBundle' %}fos_comment_comment_show_reply{% endtrans %}</button>
             </div>
         {% endif %}
         {% if children is defined %}

--- a/Resources/views/Thread/comment_new.html.twig
+++ b/Resources/views/Thread/comment_new.html.twig
@@ -22,7 +22,7 @@
         {% endif %}
     {% endblock %}
 
-    {% set url_parameters = {'id': id } %}
+    {% set url_parameters = {'id': id, '_format': 'html' } %}
     {% if parent is not null %}
         {% set url_parameters = url_parameters|merge({'parentId': parent.id}) %}
     {% endif %}


### PR DESCRIPTION
Previously, if another format was set as the default for RestBundle,
you would receive that format, breaking the comments view