### PR TITLE
Add FOSRest library dependency. What about FOSRestBundle?

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "2.*",
-        "symfony/security-bundle": "2.*"
+        "symfony/security-bundle": "2.*",
+        "friendsofsymfony/rest": "*",
     },
     "suggest": {
         "symfony/doctrine-bundle": "*",


### PR DESCRIPTION
Maybe the dependency should be against  the fosrestbundle instead of the fosrest lib, I'm not sure.
