### PR TITLE
Added editing functionality in the API + reference js implementation.

### DIFF
--- a/Acl/AclCommentManager.php
+++ b/Acl/AclCommentManager.php
@@ -119,8 +119,17 @@ class AclCommentManager implements CommentManagerInterface
             throw new AccessDeniedException();
         }
 
+        $newComment = $this->isNewComment($comment);
+
+        if (!$newComment && !$this->commentAcl->canEdit($comment)) {
+            throw new AccessDeniedException();
+        }
+
         $this->realManager->saveComment($comment);
-        $this->commentAcl->setDefaultAcl($comment);
+
+        if ($newComment) {
+            $this->commentAcl->setDefaultAcl($comment);
+        }
     }
 
     /**
@@ -143,6 +152,14 @@ class AclCommentManager implements CommentManagerInterface
     public function createComment(ThreadInterface $thread, CommentInterface $parent = null)
     {
         return $this->realManager->createComment($thread, $parent);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isNewComment(CommentInterface $comment)
+    {
+        return $this->realManager->isNewComment($comment);
     }
 
     /**

--- a/Document/CommentManager.php
+++ b/Document/CommentManager.php
@@ -143,6 +143,14 @@ class CommentManager extends BaseCommentManager
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function isNewComment(CommentInterface $comment)
+    {
+        return !$this->dm->getUnitOfWork()->isInIdentityMap($comment);
+    }
+
+    /**
      * Returns the fully qualified comment thread class name
      *
      * @return string

--- a/Entity/CommentManager.php
+++ b/Entity/CommentManager.php
@@ -147,6 +147,14 @@ class CommentManager extends BaseCommentManager
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function isNewComment(CommentInterface $comment)
+    {
+        return !$this->em->getUnitOfWork()->isInIdentityMap($comment);
+    }
+
+    /**
      * Returns the fully qualified comment thread class name
      *
      * @return string

--- a/Model/CommentManagerInterface.php
+++ b/Model/CommentManagerInterface.php
@@ -96,6 +96,15 @@ interface CommentManagerInterface
     function createComment(ThreadInterface $thread, CommentInterface $comment = null);
 
     /**
+     * Checks if the comment was already persisted before, or if it's a new one.
+     *
+     * @param CommentInterface $comment
+     *
+     * @return boolean True, if it's a new comment
+     */
+    function isNewComment(CommentInterface $comment);
+
+    /**
      * Returns the comment fully qualified class name.
      *
      * @return string

--- a/Resources/assets/js/comments.js
+++ b/Resources/assets/js/comments.js
@@ -101,7 +101,7 @@
          */
         initializeListeners: function() {
             FOS_COMMENT.thread_container.on('submit',
-                'form.fos_comment_comment_form',
+                'form.fos_comment_comment_new_form',
                 function(e) {
                     var that = $(this);
 
@@ -147,6 +147,60 @@
                     var form_holder = $(this).parent().parent().parent();
                     form_holder.parent().removeClass('fos_comment_replying');
                     form_holder.remove();
+                }
+            );
+
+            FOS_COMMENT.thread_container.on('click',
+                '.fos_comment_comment_edit_show_form',
+                function(e) {
+                    var form_data = $(this).data();
+                    var that = this;
+
+                    FOS_COMMENT.get(
+                        form_data.url,
+                        {},
+                        function(data) {
+                            var commentBody = $(that).parent().next();
+
+                            // save the old comment for the cancel function
+                            commentBody.data('original', commentBody.html());
+
+                            // show the edit form
+                            commentBody.html(data);
+                        }
+                    );
+                }
+            );
+
+            FOS_COMMENT.thread_container.on('submit',
+                'form.fos_comment_comment_edit_form',
+                function(e) {
+                    var that = $(this);
+
+                    FOS_COMMENT.post(
+                        this.action,
+                        FOS_COMMENT.serializeObject(this),
+                        // success
+                        function(data) {
+                            FOS_COMMENT.editComment(data);
+                        },
+
+                        // error
+                        function(data, statusCode) {
+                            var parent = that.parent();
+                            parent.after(data);
+                            parent.remove();
+                        }
+                    );
+
+                    e.preventDefault();
+                }
+            );
+
+            FOS_COMMENT.thread_container.on('click',
+                '.fos_comment_comment_edit_cancel',
+                function(e) {
+                    FOS_COMMENT.cancelEditComment($(this).parents('.fos_comment_comment_body'));
                 }
             );
 
@@ -200,6 +254,17 @@
                 form.children('textarea')[0].value = '';
                 form.children('.fos_comment_form_errors').remove();
             }
+        },
+
+        editComment: function(commentHtml) {
+            var commentHtml = $(commentHtml);
+            var originalCommentBody = $('#' + commentHtml.attr('id')).children('.fos_comment_comment_body');
+
+            originalCommentBody.html(commentHtml.children('.fos_comment_comment_body').html());
+        },
+
+        cancelEditComment: function(commentBody) {
+            commentBody.html(commentBody.data('original'));
         },
 
         /**

--- a/Resources/views/Thread/comment.html.twig
+++ b/Resources/views/Thread/comment.html.twig
@@ -15,6 +15,9 @@
 <div id="fos_comment_{{ comment.id }}" class="fos_comment_comment_show fos_comment_comment_depth_{{ depth }}" {% if parentId is defined %}data-parent="{{ parentId }}"{% endif %}>
     <div class="fos_comment_comment_metas">
         {% trans from 'FOSCommentBundle' %}fos_comment_comment_show_by{% endtrans %} {{ comment.authorName }} - {{ comment.createdAt|date }}
+        {% if fos_comment_can_edit_comment(comment) %}
+        <button data-url="{{ url("fos_comment_edit_thread_comment", {"id": comment.thread.id, "commentId": comment.id}) }}" class="fos_comment_comment_edit_show_form">Edit</button>
+        {% endif %}
         {% if fos_comment_can_vote(comment) %}
         <div class="fos_comment_comment_voting">
             <button data-url="{{ url("fos_comment_new_thread_comment_votes", {"id": comment.thread.id, "commentId": comment.id, "value": 1}) }}" class="fos_comment_comment_vote">{% trans from 'FOSCommentBundle' %}fos_comment_comment_show_voteup{% endtrans %}</button>

--- a/Resources/views/Thread/comment_edit.html.twig
+++ b/Resources/views/Thread/comment_edit.html.twig
@@ -1,0 +1,32 @@
+{#
+
+ This file is part of the FOSCommentBundle package.
+
+ (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+
+ This source file is subject to the MIT license that is bundled
+ with this source code in the file LICENSE.
+
+#}
+
+<div class="fos_comment_comment_form_holder">
+    <form class="fos_comment_comment_edit_form" action="{{ url('fos_comment_put_thread_comments', {'id': comment.thread.id, 'commentId': comment.id}) }}" method="POST">
+
+        {% block fos_comment_form_fields %}
+            {{ form_errors(form) }}
+            {{ form_errors(form.body) }}
+            {{ form_widget(form.body) }}
+            {{ form_widget(form._token) }}
+        {% endblock %}
+
+        <div class="fos_comment_submit">
+            <button type="button" class="fos_comment_comment_edit_cancel">Cancel</button>
+            {% block fos_comment_form_submit %}
+                <input type="submit" value="{% trans from 'FOSCommentBundle' %}fos_comment_comment_new_submit{% endtrans %}" />
+            {% endblock %}
+        </div>
+
+        <input type="hidden" name="_method" value="PUT">
+
+    </form>
+</div>

--- a/Resources/views/Thread/comment_new.html.twig
+++ b/Resources/views/Thread/comment_new.html.twig
@@ -27,7 +27,7 @@
         {% set url_parameters = url_parameters|merge({'parentId': parent.id}) %}
     {% endif %}
 
-    <form class="fos_comment_comment_form" action="{{ url('fos_comment_post_thread_comments', url_parameters) }}" data-parent="{{ parent.id|default() }}" method="POST">
+    <form class="fos_comment_comment_new_form" action="{{ url('fos_comment_post_thread_comments', url_parameters) }}" data-parent="{{ parent.id|default() }}" method="POST">
 
         {% block fos_comment_form_fields %}
             <div class="fos_comment_form_errors">

--- a/Twig/CommentExtension.php
+++ b/Twig/CommentExtension.php
@@ -60,8 +60,9 @@ class CommentExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'fos_comment_can_comment' => new \Twig_Function_Method($this, 'canComment'),
-            'fos_comment_can_vote'    => new \Twig_Function_Method($this, 'canVote'),
+            'fos_comment_can_comment'      => new \Twig_Function_Method($this, 'canComment'),
+            'fos_comment_can_edit_comment' => new \Twig_Function_Method($this, 'canEditComment'),
+            'fos_comment_can_vote'         => new \Twig_Function_Method($this, 'canVote'),
         );
     }
 
@@ -84,6 +85,22 @@ class CommentExtension extends \Twig_Extension
         }
 
         return $this->commentAcl->canReply($comment);
+    }
+
+    /**
+     * Checks if the current user is able to edit a comment.
+     *
+     * @param CommentInterface $comment
+     *
+     * @return bool If the user is able to comment
+     */
+    public function canEditComment(CommentInterface $comment)
+    {
+        if (null === $this->commentAcl) {
+            return true;
+        }
+
+        return $this->commentAcl->canEdit($comment);
     }
 
     /**


### PR DESCRIPTION
- a "BC break" because `isNewComment` is added to the
  CommentManagerInterface. This shouldn't affects users that use the
  default supported storage backends
- The html class "fos_comment_comment_form" got renamed to
  "fos_comment_comment_new_form". Any custom JavaScript implementations
  should update for this change

Tests: [![Build Status](https://secure.travis-ci.org/asm89/FOSCommentBundle.png?branch=comment-editing)](http://travis-ci.org/asm89/FOSCommentBundle)
