### PR TITLE
Comment counts for threads can be loaded asynchronously

### DIFF
--- a/Acl/AclThreadManager.php
+++ b/Acl/AclThreadManager.php
@@ -80,6 +80,22 @@ class AclThreadManager implements ThreadManagerInterface
     /**
      * {@inheritDoc}
      */
+    public function findThreadsBy(array $criteria)
+    {
+        $threads = $this->realManager->findThreadsBy($criteria);
+
+        foreach ($threads as $thread) {
+            if (!$this->threadAcl->canView($thread)) {
+                throw new AccessDeniedException();
+            }
+        }
+
+        return $threads;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function findAllThreads()
     {
         $threads = $this->realManager->findAllThreads();

--- a/Controller/ThreadController.php
+++ b/Controller/ThreadController.php
@@ -72,6 +72,25 @@ class ThreadController extends Controller
     }
 
     /**
+     * Gets the threads for the specified ids.
+     *
+     * @param Request $request
+     *
+     * @return View
+     */
+    public function getThreadsActions(Request $request)
+    {
+        $ids = $request->query->get('ids');
+
+        $threads = $this->container->get('fos_comment.manager.thread')->findThreadsBy(array('id' => $ids));
+
+        $view = View::create()
+            ->setData(array('threads' => $threads));
+
+        return $view;
+    }
+
+    /**
      * Creates a new Thread from the submitted data.
      *
      * @return View

--- a/Document/ThreadManager.php
+++ b/Document/ThreadManager.php
@@ -67,6 +67,14 @@ class ThreadManager extends BaseThreadManager
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function findThreadsBy(array $criteria)
+    {
+        return $this->repository->findBy($criteria);
+    }
+
+    /**
      * Finds all threads.
      *
      * @return array of ThreadInterface

--- a/Entity/ThreadManager.php
+++ b/Entity/ThreadManager.php
@@ -68,6 +68,14 @@ class ThreadManager extends BaseThreadManager
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function findThreadsBy(array $criteria)
+    {
+        return $this->repository->findBy($criteria);
+    }
+
+    /**
      * Finds all threads.
      *
      * @return array of ThreadInterface

--- a/Model/ThreadManagerInterface.php
+++ b/Model/ThreadManagerInterface.php
@@ -36,6 +36,15 @@ interface ThreadManagerInterface
     function findThreadBy(array $criteria);
 
     /**
+     * Finds threads by the given criteria
+     *
+     * @param array $criteria
+     *
+     * @return array of ThreadInterface
+     */
+    function findThreadsBy(array $criteria);
+
+    /**
      * Finds all threads.
      *
      * @return array of ThreadInterface

--- a/Resources/assets/js/comments.js
+++ b/Resources/assets/js/comments.js
@@ -18,10 +18,14 @@
  * <div id="fos_comment_thread">#comments</div>
  * <script type="text/javascript">
  *     // Set the thread_id if you want comments to be loaded via ajax (url to thread comments api)
- *     var fos_comment_thread_id = 'http://example.org/api/threads/a_unique_identifier_for_the_thread/comments';
+ *     var fos_comment_thread_id = 'a_unique_identifier_for_the_thread';
+ *     var fos_comment_thread_api_base_url = 'http://example.org/api/threads';
  *
- *     // Set the cors url if you want cross-domain AJAX (also needs easyXDM)
+ *     // Optionally set the cors url if you want cross-domain AJAX (also needs easyXDM)
  *     var fos_comment_remote_cors_url = 'http://example.org/cors/index.html';
+ *
+ *     // Optionally set a custom callback function to update the comment count elements
+ *     var window.fos_comment_thread_comment_count_callback = function(elem, threadObject){}
  *
  *     // Optionally set a different element than div#fos_comment_thread as container
  *     var fos_comment_thread_container = $('#other_element');
@@ -88,7 +92,7 @@
             }
 
             FOS_COMMENT.get(
-                identifier,
+                FOS_COMMENT.base_url  + '/' + encodeURIComponent(identifier) + '/comments',
                 {permalink: encodeURIComponent(permalink)},
                 function(data) {
                     FOS_COMMENT.thread_container.html(data);
@@ -222,6 +226,54 @@
                 }
             });
             return o;
+        },
+
+        loadCommentCounts: function()
+        {
+            var threadIds = [];
+            var commentCountElements = $('span.fos-comment-count');
+
+            commentCountElements.each(function(i, elem){
+                var threadId = $(elem).data('fosCommentThreadid');
+                if(threadId) {
+                    threadIds.push(threadId);
+                }
+            });
+
+            FOS_COMMENT.get(
+                FOS_COMMENT.base_url + '.json',
+                {ids: threadIds},
+                function(data) {
+                    // easyXdm doesn't always serialize
+                    if (typeof data != "object") {
+                        data = jQuery.parseJSON(data);
+                    }
+
+                    var threadData = {};
+
+                    for (var i in data.threads) {
+                        threadData[data.threads[i].id] = data.threads[i];
+                    }
+
+                    $.each(commentCountElements, function(){
+                        var threadId = $(this).data('fosCommentThreadid');
+                        if(threadId) {
+                            FOS_COMMENT.setCommentCount(this, threadData[threadId]);
+                        }
+                    });
+                }
+            );
+
+        },
+
+        setCommentCount: function(elem, threadObject) {
+            if (threadObject == undefined) {
+                elem.innerHTML = '';
+
+                return;
+            }
+
+            elem.innerHTML = threadObject.num_comments;
         }
     };
 
@@ -270,7 +322,9 @@
         };
 
         FOS_COMMENT.get= function(url, data, success, error) {
-            this.request('GET', url, data, success, error);
+            // make data serialization equals to that of jquery
+            url += '?' + jQuery.param(data);
+            this.request('GET', url, undefined, success, error);
         };
 
         /* Initialize xhr object to do cross-domain requests. */
@@ -283,10 +337,21 @@
         });
     }
 
+    // set the appropriate base url
+    FOS_COMMENT.base_url = window.fos_comment_thread_api_base_url;
+
     // Load the comment if there is a thread id defined.
     if(typeof window.fos_comment_thread_id != "undefined") {
         // get the thread comments and init listeners
         FOS_COMMENT.getThreadComments(window.fos_comment_thread_id);
+    }
+
+    if(typeof window.fos_comment_thread_comment_count_callback != "undefined") {
+        FOS_COMMENT.setCommentCount = window.fos_comment_thread_comment_count_callback;
+    }
+
+    if($('span.fos-comment-count').length > 0) {
+        FOS_COMMENT.loadCommentCounts();
     }
 
     FOS_COMMENT.initializeListeners();

--- a/Resources/views/Thread/async.html.twig
+++ b/Resources/views/Thread/async.html.twig
@@ -13,8 +13,11 @@
 
 {% javascripts '@FOSCommentBundle/Resources/assets/js/comments.js' %}
 <script type="text/javascript">
-// URI identifier for the thread comments
-var fos_comment_thread_id = '{{ path('fos_comment_get_thread_comments', {'id': id}) }}';
+// thread id
+var fos_comment_thread_id = '{{ id }}';
+
+// api base url to use for initial requests
+var fos_comment_thread_api_base_url = '{{ path('fos_comment_get_threads') }}';
 
 // Snippet for asynchronously loading the comments
 (function() {


### PR DESCRIPTION
Implements the functionality described here #163. If the code is :thumbsup: I'll update the docs and add a twig function to render the correct `<span>` element for a thread id.

This PR introduces two small BC breaks as users now need to specify the api base url for the JS implementation. This will only affect users that have inserted the javascript snippet into the pages themselves. Users including the twig async template will not be affected. The other BC break is the addition of the `ThreadManagerInterface#findThreadsBy` method.
