### PR TITLE
This fixes the case when form is customized, and textarea is not form ch...

### DIFF
--- a/Resources/assets/js/comments.js
+++ b/Resources/assets/js/comments.js
@@ -314,7 +314,7 @@
 
                 // "reset" the form
                 form = $(form[0]);
-                form.children('textarea')[0].value = '';
+                form.find('textarea').val('');
                 form.children('.fos_comment_form_errors').remove();
             }
         },


### PR DESCRIPTION
This fixes the case when form is customized, and textarea is not form child, but child of some dom element inside form, which is a regular use case. In such case old code was giving error because value attribute is accessed on a non object. This should fix it.
