### PR TITLE
Rename invalid forms name

### DIFF
--- a/Form/CommentType.php
+++ b/Form/CommentType.php
@@ -29,6 +29,6 @@ class CommentType extends AbstractType
 
     public function getName()
     {
-        return "fos_comment.comment";
+        return "fos_comment_comment";
     }
 }

--- a/Form/DeleteCommentType.php
+++ b/Form/DeleteCommentType.php
@@ -29,6 +29,6 @@ class DeleteCommentType extends AbstractType
 
     public function getName()
     {
-        return "fos_comment.delete_comment";
+        return "fos_comment_delete_comment";
     }
 }

--- a/Form/VoteType.php
+++ b/Form/VoteType.php
@@ -29,6 +29,6 @@ class VoteType extends AbstractType
 
     public function getName()
     {
-        return "fos_comment.vote";
+        return "fos_comment_vote";
     }
 }


### PR DESCRIPTION
Fix not allowed "." caracter in forms name in symfony2.0.
