### PR TITLE
findCommentTreeByCommentId() only returns 1 reply

### DIFF
--- a/Document/CommentManager.php
+++ b/Document/CommentManager.php
@@ -114,7 +114,8 @@ class CommentManager extends BaseCommentManager
 
         $sorter = $this->sortingFactory->getSorter($sorter);
 
-        $ignoreParents = $comments->getSingleResult()->getAncestors();
+        $singleComment = current($comments->toArray());
+        $ignoreParents = $singleComment->getAncestors();
 
         return $this->organiseComments($comments, $sorter, $ignoreParents);
     }


### PR DESCRIPTION
In our setup, we're using MongoDB and Doctrine's ORM to store comment. When getSingleResult() is called on $comments, the foreach loop used in organiseComments() only operates on the first comment, so the tree only ever contains 1 comment. 

By grabbing the first record using toArray(), everything works as expected.
