### PR TITLE
Empty all inputs in the form when append comment

### DIFF
--- a/Resources/assets/js/comments.js
+++ b/Resources/assets/js/comments.js
@@ -314,7 +314,7 @@
 
                 // "reset" the form
                 form = $(form[0]);
-                form.find('textarea, input').not('[type="submit"][type="reset"][type="hidden"][type="button"]').val('');
+                form.find('textarea, input').not('[type="submit"], [type="reset"], [type="hidden"], [type="button"]').val('');
                 form.children('.fos_comment_form_errors').remove();
             }
         },


### PR DESCRIPTION
Inputs is empty when creating custom forms, not textarea only.

I've got create a custom form, but the JS don't empty all my fields, so I think it's softer with this small change.
