### PR TITLE
'fos_comment_comment_edit' added in russian translation

### DIFF
--- a/Resources/translations/FOSCommentBundle.ru.yml
+++ b/Resources/translations/FOSCommentBundle.ru.yml
@@ -24,4 +24,5 @@ fos_comment_thread_open:                      Открыть тред
 fos_comment_thread_comment_count:             %count% комментарий|%count% комментария|%count% комментариев
 fos_comment_comment_delete:                   Удалить комментарий
 fos_comment_comment_undelete:                 Обновить комментарий
+fos_comment_comment_edit:                     Изменить комментарий
 fos_comment_comment_deleted:                  "[удалено]"


### PR DESCRIPTION
'fos_comment_comment_edit' added and fixed bug in 'fos_comment_thread_comment_count' - incorrect '%' cause problems. Russian translation file.
