### PR TITLE
fired event when a new comment is added from the parent form

### DIFF
--- a/Resources/assets/js/comments.js
+++ b/Resources/assets/js/comments.js
@@ -336,6 +336,7 @@
             } else {
                 // Insert the comment
                 form.after(commentHtml);
+                form.trigger('fos_comment_add_comment', commentHtml);
 
                 // "reset" the form
                 form = $(form[0]);


### PR DESCRIPTION
In  #274 I forgot to fire a `fos_comment_add_comment event` when a new comment is added from the parent form. 
