### PR TITLE
Sorting for javascript

### DIFF
--- a/Controller/ThreadController.php
+++ b/Controller/ThreadController.php
@@ -415,7 +415,7 @@ class ThreadController extends Controller
             ->setData(array(
                 'comments' => $comments,
                 'displayDepth' => $displayDepth,
-                'sorter' => 'date',
+                'sorter' => $sorter,
                 'thread' => $thread,
                 'view' => $viewMode,
             ))

--- a/Resources/assets/js/comments.js
+++ b/Resources/assets/js/comments.js
@@ -124,7 +124,7 @@
                         FOS_COMMENT.serializeObject(this),
                         // success
                         function(data, statusCode) {
-                            FOS_COMMENT.appendComment(data, that);
+                            FOS_COMMENT.insertComment(data, that);
                             that.trigger('fos_comment_new_comment', data);
                         },
                         // error
@@ -317,35 +317,31 @@
             );
         },
 
-        appendComment: function(commentHtml, form) {
-            var form_data = form.data();
+        insertComment: function(commentHtml, form) {
+            var form_data = form.data(),
+                position  = FOS_COMMENT.thread_container.data('new-position'),
+                group     = form.parents('.fos_comment_comment_group'),
+                comments  = group.find('.fos_comment_comments:first');
 
-            if('' != form_data.parent) {
-                var form_parent = form.closest('.fos_comment_comment_form_holder');
-
-                // reply button holder
-                var reply_button_holder = form.closest('.fos_comment_comment_reply');
-
-                var comment_element = form.closest('.fos_comment_comment_show')
-                    .children('.fos_comment_comment_replies');
-
-                reply_button_holder.removeClass('fos_comment_replying');
-
-                comment_element.prepend(commentHtml);
-                comment_element.trigger('fos_comment_add_comment', commentHtml);
-
-                // Remove the form
-                form_parent.remove();
+            if (form_data.parent) {
+                // Replying to a comment, remove the form entirely
+                form.closest('.fos_comment_comment_reply').removeClass('fos_comment_replying');
+                form.closest('.fos_comment_comment_form_holder').remove();
             } else {
-                // Insert the comment
-                form.after(commentHtml);
-                form.trigger('fos_comment_add_comment', commentHtml);
-
-                // "reset" the form
+                // Using the primary new comment form, reset it to a
+                // raw state
                 form = $(form[0]);
                 form.find('textarea').val('');
                 form.children('.fos_comment_form_errors').remove();
             }
+
+            if ('bottom' === position) {
+                comments.append(commentHtml);
+            } else {
+                comments.prepend(commentHtml);
+            }
+
+            form.trigger('fos_comment_add_comment', commentHtml);
         },
 
         editComment: function(commentHtml) {

--- a/Resources/assets/js/comments.js
+++ b/Resources/assets/js/comments.js
@@ -92,7 +92,7 @@
         getThreadComments: function(identifier, permalink) {
             var event = jQuery.Event('fos_comment_before_load_thread');
 
-            event.identifier = identifier;
+            event.identifier = identifier || FOS_COMMENT.thread_container.data('thread-id');
             event.params = {
                 permalink: encodeURIComponent(permalink || window.location.href)
             };
@@ -495,9 +495,11 @@
     // set the appropriate base url
     FOS_COMMENT.base_url = window.fos_comment_thread_api_base_url;
 
-    // Load the comment if there is a thread id defined.
-    if(typeof window.fos_comment_thread_id != "undefined") {
-        // get the thread comments and init listeners
+    // Check to see if we've got a thread id supporting both the
+    // new and legacy method of supplying an identifier.
+    if (FOS_COMMENT.thread_container.data('thread-id')) {
+        FOS_COMMENT.getThreadComments();
+    } else if (typeof window.fos_comment_thread_id != "undefined") {
         FOS_COMMENT.getThreadComments(window.fos_comment_thread_id);
     }
 

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -15,6 +15,7 @@
 
     <services>
         <service id="fos_comment.twig.comment_extension" class="FOS\CommentBundle\Twig\CommentExtension" public="false">
+            <argument type="service" id="fos_comment.sorting_factory" />
             <argument type="service" id="fos_comment.acl.comment" on-invalid="null" />
             <argument type="service" id="fos_comment.acl.vote" on-invalid="null" />
             <argument type="service" id="fos_comment.acl.thread" on-invalid="null" />

--- a/Resources/doc/4-enable_comments_on_a_page.md
+++ b/Resources/doc/4-enable_comments_on_a_page.md
@@ -14,8 +14,15 @@ the page load.
 
 And the following code at a desired place in the template to load the comments:
 
+```jinja
+{% include 'FOSCommentBundle:Thread:async.html.twig' with { id: 'foo' } %}
 ```
-{% include 'FOSCommentBundle:Thread:async.html.twig' with {'id': 'foo'} %}
+
+To be able to sort comments by something other than your default sorting mechanism
+include a sorting variable:
+
+```jinja
+{% include 'FOSCommentBundle:Thread:async.html.twig' with { id: 'foo', sorter: 'date_asc' } %}
 ```
 
 That's the basic setup! For additional information and configuration check the ... section and the cookbook.

--- a/Resources/views/Thread/async.html.twig
+++ b/Resources/views/Thread/async.html.twig
@@ -9,7 +9,9 @@
 
 #}
 
-<div id="fos_comment_thread" class="fos_comment_comment_group" data-thread-id="{{ id }}"></div>
+{% set sorter   = fos_comment_sorter(sorter | default(null)) %}
+
+<div id="fos_comment_thread" class="fos_comment_comment_group" data-thread-id="{{ id }}" data-new-position="{{ sorter.newPosition }}"></div>
 
 {% javascripts '@FOSCommentBundle/Resources/assets/js/comments.js' %}
 <script type="text/javascript">

--- a/Resources/views/Thread/async.html.twig
+++ b/Resources/views/Thread/async.html.twig
@@ -9,13 +9,10 @@
 
 #}
 
-<div id="fos_comment_thread"></div>
+<div id="fos_comment_thread" class="fos_comment_comment_group" data-thread-id="{{ id }}"></div>
 
 {% javascripts '@FOSCommentBundle/Resources/assets/js/comments.js' %}
 <script type="text/javascript">
-// thread id
-var fos_comment_thread_id = '{{ id }}';
-
 // api base url to use for initial requests
 var fos_comment_thread_api_base_url = '{{ path('fos_comment_get_threads') }}';
 

--- a/Resources/views/Thread/comment_content.html.twig
+++ b/Resources/views/Thread/comment_content.html.twig
@@ -10,7 +10,7 @@
 #}
 
 {% block fos_comment_comment %}
-<div id="fos_comment_{{ comment.id }}" class="fos_comment_comment_show fos_comment_comment_depth_{{ depth }}" {% if parentId is defined %}data-parent="{{ parentId }}"{% endif %}>
+<div id="fos_comment_{{ comment.id }}" class="fos_comment_comment_group fos_comment_comment_show fos_comment_comment_depth_{{ depth }}" {% if parentId is defined %}data-parent="{{ parentId }}"{% endif %}>
 
     <div class="fos_comment_comment_metas">
         {% block fos_comment_comment_metas %}

--- a/Resources/views/Thread/comment_content.html.twig
+++ b/Resources/views/Thread/comment_content.html.twig
@@ -10,7 +10,7 @@
 #}
 
 {% block fos_comment_comment %}
-<div id="fos_comment_{{ comment.id }}" class="fos_comment_comment_group fos_comment_comment_show fos_comment_comment_depth_{{ depth }}" {% if parentId is defined %}data-parent="{{ parentId }}"{% endif %}>
+<div id="fos_comment_{{ comment.id }}" class="fos_comment_comment_group fos_comment_comment_show" data-depth="{{ depth }}" {% if parentId is defined %}data-parent="{{ parentId }}"{% endif %}>
 
     <div class="fos_comment_comment_metas">
         {% block fos_comment_comment_metas %}
@@ -79,14 +79,9 @@
                 </div>
             {% endif %}
 
-            <div class="fos_comment_comment_replies">
-
-
-                {% if children is defined %}
-                    {% include "FOSCommentBundle:Thread:comments.html.twig" with { "comments": children, "depth": depth + 1, "parentId": comment.id, "view": view } %}
-                {% endif %}
-
-            </div>
+            {% if children is defined %}
+                {% include "FOSCommentBundle:Thread:comments.html.twig" with { "comments": children, "depth": depth + 1, "parentId": comment.id, "view": view } %}
+            {% endif %}
         {% elseif view is sameas('flat') and children is defined %}
             {% include "FOSCommentBundle:Thread:comments.html.twig" with { "comments": children, "depth": depth + 1, "parentId": comment.id, "view": view } %}
         {% endif %}

--- a/Resources/views/Thread/comments.html.twig
+++ b/Resources/views/Thread/comments.html.twig
@@ -29,6 +29,8 @@
     <h3>{% transchoice count with {'%count%': count} from "FOSCommentBundle" %}fos_comment_thread_comment_count{% endtranschoice %}</h3>
 {% endif %}
 
+<div class="fos_comment_comments">
 {% for commentinfo in comments %}
     {% include "FOSCommentBundle:Thread:comment.html.twig" with { "children": commentinfo.children, "comment": commentinfo.comment, "depth": depth, "view": view } %}
 {% endfor %}
+</div>

--- a/Sorting/AbstractOrderSorting.php
+++ b/Sorting/AbstractOrderSorting.php
@@ -21,7 +21,7 @@ use InvalidArgumentException;
  */
 abstract class AbstractOrderSorting implements SortingInterface
 {
-    const ASC = 'ASC';
+    const ASC  = 'ASC';
     const DESC = 'DESC';
 
     private $order;
@@ -114,4 +114,17 @@ abstract class AbstractOrderSorting implements SortingInterface
      * @return -1|0|1           As expected for usort()
      */
     abstract protected function compare(CommentInterface $a, CommentInterface $b);
+
+    /**
+     * Returns the position constant to be used to position new
+     * comments made to a thread.
+     *
+     * @return string
+     */
+    public function getNewPosition()
+    {
+        return $this->order === static::ASC ?
+            static::POSITION_BOTTOM :
+            static::POSITION_TOP;
+    }
 }

--- a/Sorting/SortingInterface.php
+++ b/Sorting/SortingInterface.php
@@ -20,6 +20,9 @@ use FOS\CommentBundle\Model\Tree;
  */
 interface SortingInterface
 {
+    const POSITION_TOP = 'top';
+    const POSITION_BOTTOM = 'bottom';
+
     /**
      * Takes an array of Tree instances and sorts them.
      *
@@ -35,4 +38,12 @@ interface SortingInterface
      * @return array
      */
     public function sortFlat(array $comments);
+
+    /**
+     * Returns the position constant to be used to position new
+     * comments made to a thread.
+     *
+     * @return string
+     */
+    public function getNewPosition();
 }

--- a/Twig/CommentExtension.php
+++ b/Twig/CommentExtension.php
@@ -12,12 +12,14 @@
 namespace FOS\CommentBundle\Twig;
 
 use FOS\CommentBundle\Acl\CommentAclInterface;
-use FOS\CommentBundle\Model\CommentInterface;
-use FOS\CommentBundle\Model\ThreadInterface;
-use FOS\CommentBundle\Model\VotableCommentInterface;
-use FOS\CommentBundle\Model\RawCommentInterface;
 use FOS\CommentBundle\Acl\ThreadAclInterface;
 use FOS\CommentBundle\Acl\VoteAclInterface;
+use FOS\CommentBundle\Model\CommentInterface;
+use FOS\CommentBundle\Model\RawCommentInterface;
+use FOS\CommentBundle\Model\ThreadInterface;
+use FOS\CommentBundle\Model\VotableCommentInterface;
+use FOS\CommentBundle\Sorting\SortingFactory;
+use FOS\CommentBundle\Sorting\SortingInterface;
 
 /**
  * Extends Twig to provide some helper functions for the CommentBundle.
@@ -26,15 +28,32 @@ use FOS\CommentBundle\Acl\VoteAclInterface;
  */
 class CommentExtension extends \Twig_Extension
 {
+    /**
+     * @var \FOS\CommentBundle\Acl\CommentAclInterface|null
+     */
     protected $commentAcl;
+
+    /**
+     * @var \FOS\CommentBundle\Acl\VoteAclInterface|null
+     */
     protected $voteAcl;
+
+    /**
+     * @var \FOS\CommentBundle\Acl\ThreadAclInterface|null
+     */
     protected $threadAcl;
 
-    public function __construct(CommentAclInterface $commentAcl = null, VoteAclInterface $voteAcl = null, ThreadAclInterface $threadAcl = null)
+    /**
+     * @var \FOS\CommentBundle\Sorting\SortingFactory
+     */
+    protected $sortingFactory;
+
+    public function __construct(SortingFactory $sortingFactory, CommentAclInterface $commentAcl = null, VoteAclInterface $voteAcl = null, ThreadAclInterface $threadAcl = null)
     {
-        $this->commentAcl = $commentAcl;
-        $this->voteAcl    = $voteAcl;
-        $this->threadAcl  = $threadAcl;
+        $this->commentAcl     = $commentAcl;
+        $this->sortingFactory = $sortingFactory;
+        $this->threadAcl      = $threadAcl;
+        $this->voteAcl        = $voteAcl;
     }
 
     public function getTests()
@@ -99,6 +118,7 @@ class CommentExtension extends \Twig_Extension
             'fos_comment_can_edit_comment'   => new \Twig_Function_Method($this, 'canEditComment'),
             'fos_comment_can_edit_thread'    => new \Twig_Function_Method($this, 'canEditThread'),
             'fos_comment_can_comment_thread' => new \Twig_Function_Method($this, 'canCommentThread'),
+            'fos_comment_sorter'             => new \Twig_Function_Method($this, 'getSorter'),
         );
     }
 
@@ -218,6 +238,17 @@ class CommentExtension extends \Twig_Extension
     {
         return $thread->isCommentable()
             && (null === $this->commentAcl || $this->commentAcl->canCreate());
+    }
+
+    /**
+     * Returns a sorter given its name. If not supplied, the
+     * default sorter will be returned.
+     *
+     * @param SortingInterface $sorterName
+     */
+    public function getSorter($sorterName = null)
+    {
+        return $this->sortingFactory->getSorter($sorterName);
     }
 
     /**

--- a/UPDATE.markdown
+++ b/UPDATE.markdown
@@ -1,17 +1,27 @@
 2.0.0-beta1 to 2.0.0-beta2
 
- * Thread identifiers are now specified by adding a `data-thread-id=""` attribute to the thread container. The old method is deprecated and will be removed in 3.0.
- * Introduced a new method to SortingInterface, `getNewPosition` which should return one of the two POSITION_ constants provided in the interface.
- * Minor changes to the templates to facilitate different sorting orders in javascript
+ * Thread identifiers are now specified by adding a `data-thread-id=""`
+   attribute to the thread container. The old method is deprecated and
+   will be removed in 3.0.
+ * Introduced a new method to SortingInterface, `getNewPosition` which
+   should return one of the two POSITION_ constants provided in the
+   interface.
+ * Templates `comment_content.html.twig`, `comments.html.twig` and
+   `async.html.twig` have had required modifications made and changes
+   will need to be made to overridden templates if you use the reference
+   javascript.
 
 1.1.x to 2.0.0-beta1
 
- * No changes are required. 2.0.0 primarily introduces Symfony 2.1 support while breaking BC with Symfony 2.0.
+ * No changes are required. 2.0.0 primarily introduces Symfony 2.1 support
+   while breaking BC with Symfony 2.0.
 
 1.0.0 to 1.1.0
 
- * `Resources/Thread/comment.html.twig` has changed, adding a rawBody option. This change is not relevant unless you are going to use RawComments
- * If you don't use the async template to render the comments, you will need to add a new variable defining the base url of the api:
+ * `Resources/Thread/comment.html.twig` has changed, adding a rawBody
+   option. This change is not relevant unless you are going to use RawComments
+ * If you don't use the async template to render the comments, you will
+   need to add a new variable defining the base url of the api:
 
  ``` javascript
  var fos_comment_thread_api_base_url = 'http://example.org/api/threads';
@@ -19,21 +29,27 @@
  ```
  * A new method `ThreadManagerInterface#findThreadsBy` was added.
  * A new method `ThreadManagerInterface#isNewThread()` was added.
- * `ThreadInterface#setIsCommentable` was renamed to `ThreadInterface#setCommentable`
+ * `ThreadInterface#setIsCommentable` was renamed to
+   `ThreadInterface#setCommentable`
  * A new method `CommentManagerInterface#isNewComment` was added.
- * The html class `fos_comment_comment_form` was renamed to `fos_comment_comment_new_form`. Custom javascript implementations should be adjusted for this change.
+ * The html class `fos_comment_comment_form` was renamed to
+   `fos_comment_comment_new_form`. Custom javascript implementations should
+   be adjusted for this change.
  * A new method `CommentInterface#getState` was added.
  * A new method `CommentInterface#setState` was added.
  * A new method `CommentInterface#getPreviousState` was added.
- * A new field was added to `Document\Comment` and `Entity\Comment`. ORM users should update their schema.
+ * A new field was added to `Document\Comment` and `Entity\Comment`. ORM
+   users should update their schema.
 
 
 0.9.2 to 1.0.0
 
- * You need to remove comment.js previously used by this bundle. async.html.twig now includes its
-   own javascript file automatically.
- * There is now a dependency on FOSRestBundle. Check the installation documentation for details.
- * Routing has changed, you must replace your existing fos_comment route import to
+ * You need to remove comment.js previously used by this bundle.
+   async.html.twig now includes its own javascript file automatically.
+ * There is now a dependency on FOSRestBundle. Check the installation
+   documentation for details.
+ * Routing has changed, you must replace your existing fos_comment route
+   import to
 
    ``` yaml
    fos_comment_api:
@@ -42,8 +58,9 @@
        prefix: /comment/api
    ```
 
- * The way to include comments in a page has changed, importing an asynchronous javascript template into
-   your page which will trigger an asynchronous load of a comment thread using the REST api.
+ * The way to include comments in a page has changed, importing an
+   asynchronous javascript template into your page which will trigger
+   an asynchronous load of a comment thread using the REST api.
 
    ``` jinja
    {% include 'FOSCommentBundle:Thread:async.html.twig' with {'id': 'foo'} %}
@@ -51,22 +68,26 @@
 
 2012-01-21
 
- * Blamers, Creators and Spam Detection classes have been moved to an Event Dispatcher based set up.
-   Documentation on how to use this feature is expected to be available with the release of v1.0.0
- * CommentManager, ThreadManager and VoteManager's interfaces have changed slightly, renaming add*()
-   methods to save*().
+ * Blamers, Creators and Spam Detection classes have been moved to an
+   Event Dispatcher based set up. Documentation on how to use this feature
+   is expected to be available with the release of v1.0.0
+ * CommentManager, ThreadManager and VoteManager's interfaces have changed
+   slightly, renaming add*() methods to save*().
 
 2011-08-10
 
- * ORM: Column names like ``createdAt`` have been changed to underscore delimited format ``created_at``.
-   Schema update and cache clearance is required for migration.
+ * ORM: Column names like ``createdAt`` have been changed to underscore
+   delimited format ``created_at``. Schema update and cache clearance is
+   required for migration.
 
 2011-08-08
 
  * Thread property ``identifier`` has been renamed to ``id``
- * ORM: Comment property ancestors has been marked as not null and should default to an empty string
+ * ORM: Comment property ancestors has been marked as not null and should
+   default to an empty string
 
 2011-07-31
 
- * The supplied Thread classes are now mapped-superclasses, you must extend and implement an appropriate
-   class from Entity/ or Document/ for your application and adjust your configuration accordingly.
+ * The supplied Thread classes are now mapped-superclasses, you must
+   extend and implement an appropriate class from Entity/ or Document/ for
+   your application and adjust your configuration accordingly.

--- a/UPDATE.markdown
+++ b/UPDATE.markdown
@@ -1,6 +1,8 @@
 2.0.0-beta1 to 2.0.0-beta2
 
  * Thread identifiers are now specified by adding a `data-thread-id=""` attribute to the thread container. The old method is deprecated and will be removed in 3.0.
+ * Introduced a new method to SortingInterface, `getNewPosition` which should return one of the two POSITION_ constants provided in the interface.
+ * Minor changes to the templates to facilitate different sorting orders in javascript
 
 1.1.x to 2.0.0-beta1
 

--- a/UPDATE.markdown
+++ b/UPDATE.markdown
@@ -1,3 +1,11 @@
+2.0.0-beta1 to 2.0.0-beta2
+
+ * Thread identifiers are now specified by adding a `data-thread-id=""` attribute to the thread container. The old method is deprecated and will be removed in 3.0.
+
+1.1.x to 2.0.0-beta1
+
+ * No changes are required. 2.0.0 primarily introduces Symfony 2.1 support while breaking BC with Symfony 2.0.
+
 1.0.0 to 1.1.0
 
  * `Resources/Thread/comment.html.twig` has changed, adding a rawBody option. This change is not relevant unless you are going to use RawComments

--- a/UPDATE.markdown
+++ b/UPDATE.markdown
@@ -10,6 +10,10 @@
    `async.html.twig` have had required modifications made and changes
    will need to be made to overridden templates if you use the reference
    javascript.
+ * Removed fos_comment_comment_replies class in favour of
+   fos_comment_comments which also encapsulates the entire comment tree
+ * Removed the fos_comment_comment_depth_N class in favour of a
+   data-depth attribute.
 
 1.1.x to 2.0.0-beta1
 


### PR DESCRIPTION
Implements a better appendComment method (renamed to insertComment) that can handle adding both at the beginning and the end of comments at a specific branch depth.

Additionally contains a change to the way the thread identifier is specified, using a data-thread-id attribute on the thread container.

I would appreciate testing of this feature to make sure it doesnt break existing installations. There are template modifications that will need to be performed if you have overridden either `comment_content.html.twig`, `comments.html.twig` or `async.html.twig`.