### PR TITLE
Fixed form reset

### DIFF
--- a/Resources/assets/js/comments.js
+++ b/Resources/assets/js/comments.js
@@ -343,7 +343,7 @@
 
                 // "reset" the form
                 form = $(form[0]);
-                form.reset();
+                form[0].reset();
                 form.children('.fos_comment_form_errors').remove();
             }
         },


### PR DESCRIPTION
`reset()` is a native javascript function and it does not work on jQuery objects.
