### PR TITLE
Pluralize validation for message is too short

### DIFF
--- a/Resources/config/validation.xml
+++ b/Resources/config/validation.xml
@@ -22,7 +22,7 @@
             </constraint>
             <constraint name="MinLength">
                 <option name="limit">3</option>
-                <option name="message">The message is too short</option>
+                <option name="message">The message is too short|The message is too short</option>
             </constraint>
         </property>
     </class>


### PR DESCRIPTION
Same case as 
https://github.com/FriendsOfSymfony/FOSMessageBundle/issues/62
