### PR TITLE
add jms/serializer-bundle in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "php": ">=5.3.2",
         "symfony/symfony": "2.1.*@stable",
         "sensio/framework-extra-bundle": ">=2.0,<2.3-dev",
-        "friendsofsymfony/rest-bundle": "*"
+        "friendsofsymfony/rest-bundle": "*",
+        "jms/serializer-bundle": "*"
     },
     "suggest": {
         "friendsofsymfony/user-bundle": "Allows for user integration.",


### PR DESCRIPTION
The [installation](https://github.com/FriendsOfSymfony/FOSCommentBundle/blob/master/Resources/doc/1-setting_up_the_bundle.md) mentions that we should enable the `jms/serializer-bundle`, but the serializer bundle is not installed with comment bundle by default, so either should we "require" the `jms/serializer-bundle` in `composer.json`, which I prefer, or mention it in the installation.
