### PR TITLE
Re-Added the fos_comment_comment_replies element wrapping children

### DIFF
--- a/Resources/views/Thread/comment_content.html.twig
+++ b/Resources/views/Thread/comment_content.html.twig
@@ -79,7 +79,9 @@
                 </div>
             {% endif %}
 
-            {% include "FOSCommentBundle:Thread:comments.html.twig" with { "comments": children | default([]), "depth": depth + 1, "parentId": comment.id, "view": view } %}
+            <div class="fos_comment_comment_replies">
+                {% include "FOSCommentBundle:Thread:comments.html.twig" with { "comments": children | default([]), "depth": depth + 1, "parentId": comment.id, "view": view } %}
+            </div>
         {% elseif view is sameas('flat') and children is defined %}
             {% include "FOSCommentBundle:Thread:comments.html.twig" with { "comments": children, "depth": depth + 1, "parentId": comment.id, "view": view } %}
         {% endif %}


### PR DESCRIPTION
Since the last merge in master, replies are not appened/prepened anymore.
Regarding the comparison, it seems the element wrapping replies has been removed (see https://github.com/FriendsOfSymfony/FOSCommentBundle/compare/7ff537e157...8e278e85df)
