### PR TITLE
Add another text for the comment edit button

### DIFF
--- a/Resources/translations/FOSCommentBundle.da.yml
+++ b/Resources/translations/FOSCommentBundle.da.yml
@@ -3,6 +3,9 @@ fos_comment_comment_new_headline:             Tilføj ny kommentar
 fos_comment_comment_new_submit:               Send
 fos_comment_comment_new_cancel:               Afbryd
 
+fos_comment_comment_edit_submit:              Send
+fos_comment_comment_edit_cancel:              Afbryd
+
 fos_comment_comment_reply_reply_to:           Svarer %name%
 fos_comment_comment_reply_cancel:             Afbryd
 

--- a/Resources/translations/FOSCommentBundle.de.yml
+++ b/Resources/translations/FOSCommentBundle.de.yml
@@ -3,6 +3,9 @@ fos_comment_comment_new_headline:             Schreiben Sie Ihren Kommentar
 fos_comment_comment_new_submit:               Senden
 fos_comment_comment_new_cancel:               Abbrechen
 
+fos_comment_comment_edit_submit:              Senden
+fos_comment_comment_edit_cancel:              Abbrechen
+
 fos_comment_comment_reply_reply_to:           Antworten auf %name%
 fos_comment_comment_reply_cancel:             Abbrechen
 

--- a/Resources/translations/FOSCommentBundle.en.yml
+++ b/Resources/translations/FOSCommentBundle.en.yml
@@ -3,6 +3,9 @@ fos_comment_comment_new_headline:             Add New Comment
 fos_comment_comment_new_submit:               Post
 fos_comment_comment_new_cancel:               Cancel
 
+fos_comment_comment_edit_submit:              Post
+fos_comment_comment_edit_cancel:              Cancel
+
 fos_comment_comment_reply_reply_to:           Replying to %name%
 fos_comment_comment_reply_cancel:             Cancel
 

--- a/Resources/translations/FOSCommentBundle.es.yml
+++ b/Resources/translations/FOSCommentBundle.es.yml
@@ -3,6 +3,9 @@ fos_comment_comment_new_headline:             Dejar un comentario
 fos_comment_comment_new_submit:               Enviar comentario
 fos_comment_comment_new_cancel:               Cancelar
 
+fos_comment_comment_edit_submit:              Enviar comentario
+fos_comment_comment_edit_cancel:              Cancelar
+
 fos_comment_comment_reply_reply_to:           Responder a %name%
 fos_comment_comment_reply_cancel:             Cancelar
 

--- a/Resources/translations/FOSCommentBundle.et.yml
+++ b/Resources/translations/FOSCommentBundle.et.yml
@@ -3,6 +3,9 @@ fos_comment_comment_new_headline:             Lisa uus kommentaar
 fos_comment_comment_new_submit:               Postita
 fos_comment_comment_new_cancel:               Tühista
 
+fos_comment_comment_edit_submit:              Postita
+fos_comment_comment_edit_cancel:              Tühista
+
 fos_comment_comment_reply_reply_to:           Vasta %name%
 fos_comment_comment_reply_cancel:             Tühista
 

--- a/Resources/translations/FOSCommentBundle.fa_IR.yml
+++ b/Resources/translations/FOSCommentBundle.fa_IR.yml
@@ -3,6 +3,9 @@ fos_comment_comment_new_headline:             افزودن نظر
 fos_comment_comment_new_submit:               فرستادن
 fos_comment_comment_new_cancel:               لغو
 
+fos_comment_comment_edit_submit:              فرستادن
+fos_comment_comment_edit_cancel:              لغو
+
 fos_comment_comment_reply_reply_to:           جواب دادن به %name%
 fos_comment_comment_reply_cancel:             لغو
 

--- a/Resources/translations/FOSCommentBundle.fi.yml
+++ b/Resources/translations/FOSCommentBundle.fi.yml
@@ -3,6 +3,9 @@ fos_comment_comment_new_headline:             Lisää uusi kommentti
 fos_comment_comment_new_submit:               Lähetä
 fos_comment_comment_new_cancel:               Peru
 
+fos_comment_comment_edit_submit:              Lähetä
+fos_comment_comment_edit_cancel:              Peru
+
 fos_comment_comment_reply_reply_to:           Vastaus käyttäjän %name% kommenttiin
 fos_comment_comment_reply_cancel:             Peru
 

--- a/Resources/translations/FOSCommentBundle.fr.yml
+++ b/Resources/translations/FOSCommentBundle.fr.yml
@@ -3,6 +3,9 @@ fos_comment_comment_new_headline:             Ajouter un commentaire
 fos_comment_comment_new_submit:               Poster
 fos_comment_comment_new_cancel:               Annuler
 
+fos_comment_comment_edit_submit:              Poster
+fos_comment_comment_edit_cancel:              Annuler
+
 fos_comment_comment_reply_reply_to:           Répondre à %name%
 fos_comment_comment_reply_cancel:             Annuler
 

--- a/Resources/translations/FOSCommentBundle.it.yml
+++ b/Resources/translations/FOSCommentBundle.it.yml
@@ -3,6 +3,9 @@ fos_comment_comment_new_headline:             Aggiungi commento
 fos_comment_comment_new_submit:               Invia
 fos_comment_comment_new_cancel:               Annulla
 
+fos_comment_comment_edit_submit:              Invia
+fos_comment_comment_edit_cancel:              Annulla
+
 fos_comment_comment_reply_reply_to:           In risposta a %name%
 fos_comment_comment_reply_cancel:             Annulla
 

--- a/Resources/translations/FOSCommentBundle.mn.yml
+++ b/Resources/translations/FOSCommentBundle.mn.yml
@@ -3,6 +3,9 @@ fos_comment_comment_new_headline:             Шинэ сэтгэгдэл нэм
 fos_comment_comment_new_submit:               Илгээх
 fos_comment_comment_new_cancel:               Цуцлах
 
+fos_comment_comment_edit_submit:              Илгээх
+fos_comment_comment_edit_cancel:              Цуцлах
+
 fos_comment_comment_reply_reply_to:           %name% -д хариу бичих
 fos_comment_comment_reply_cancel:             Цуцлах
 

--- a/Resources/translations/FOSCommentBundle.pl.yml
+++ b/Resources/translations/FOSCommentBundle.pl.yml
@@ -3,6 +3,9 @@ fos_comment_comment_new_headline:             Dodaj nowy komentarz
 fos_comment_comment_new_submit:               Napisz
 fos_comment_comment_new_cancel:               Anuluj
 
+fos_comment_comment_edit_submit:              Napisz
+fos_comment_comment_edit_cancel:              Anuluj
+
 fos_comment_comment_reply_reply_to:           Odpowiadając na %name%
 fos_comment_comment_reply_cancel:             Anuluj
 

--- a/Resources/translations/FOSCommentBundle.pt.yml
+++ b/Resources/translations/FOSCommentBundle.pt.yml
@@ -3,6 +3,9 @@ fos_comment_comment_new_headline:             Adicione um Novo Comentário
 fos_comment_comment_new_submit:               Publicar
 fos_comment_comment_new_cancel:               Cancelar
 
+fos_comment_comment_edit_submit:              Publicar
+fos_comment_comment_edit_cancel:              Cancelar
+
 fos_comment_comment_reply_reply_to:           Respondendo para %name%
 fos_comment_comment_reply_cancel:             Cancelar
 

--- a/Resources/translations/FOSCommentBundle.ru.yml
+++ b/Resources/translations/FOSCommentBundle.ru.yml
@@ -3,6 +3,9 @@ fos_comment_comment_new_headline:             Добавить новый ком
 fos_comment_comment_new_submit:               Ответить
 fos_comment_comment_new_cancel:               Отмена
 
+fos_comment_comment_edit_submit:              Ответить
+fos_comment_comment_edit_cancel:              Отмена
+
 fos_comment_comment_reply_reply_to:           Ответ на %name%
 fos_comment_comment_reply_cancel:             Отмена
 

--- a/Resources/translations/FOSCommentBundle.sl.yml
+++ b/Resources/translations/FOSCommentBundle.sl.yml
@@ -3,6 +3,9 @@ fos_comment_comment_new_headline:             Dodaj nov komentar
 fos_comment_comment_new_submit:               Objavi
 fos_comment_comment_new_cancel:               Prekliči
 
+fos_comment_comment_edit_submit:              Objavi
+fos_comment_comment_edit_cancel:              Prekliči
+
 fos_comment_comment_reply_reply_to:           Odgovor za %name%
 fos_comment_comment_reply_cancel:             Prekliči
 

--- a/Resources/translations/FOSCommentBundle.sr_Cyrl.yml
+++ b/Resources/translations/FOSCommentBundle.sr_Cyrl.yml
@@ -3,6 +3,9 @@ fos_comment_comment_new_headline:             Додај нови комента
 fos_comment_comment_new_submit:               Пошаљи
 fos_comment_comment_new_cancel:               Откажи
 
+fos_comment_comment_edit_submit:              Пошаљи
+fos_comment_comment_edit_cancel:              Откажи
+
 fos_comment_comment_reply_reply_to:           Одговори %name%
 fos_comment_comment_reply_cancel:             Откажи
 

--- a/Resources/translations/FOSCommentBundle.sr_Latn.yml
+++ b/Resources/translations/FOSCommentBundle.sr_Latn.yml
@@ -3,6 +3,9 @@ fos_comment_comment_new_headline:             Dodaj novi komentar
 fos_comment_comment_new_submit:               Pošalji
 fos_comment_comment_new_cancel:               Otkaži
 
+fos_comment_comment_edit_submit:              Pošalji
+fos_comment_comment_edit_cancel:              Otkaži
+
 fos_comment_comment_reply_reply_to:           Odgovori %name%
 fos_comment_comment_reply_cancel:             Otkaži
 

--- a/Resources/translations/FOSCommentBundle.zh_CN.yml
+++ b/Resources/translations/FOSCommentBundle.zh_CN.yml
@@ -3,6 +3,9 @@ fos_comment_comment_new_headline:             发表新讨论
 fos_comment_comment_new_submit:               提交
 fos_comment_comment_new_cancel:               取消
 
+fos_comment_comment_edit_submit:              提交
+fos_comment_comment_edit_cancel:              取消
+
 fos_comment_comment_reply_reply_to:           回复 %name%
 fos_comment_comment_reply_cancel:             取消
 

--- a/Resources/views/Thread/comment_edit.html.twig
+++ b/Resources/views/Thread/comment_edit.html.twig
@@ -20,9 +20,9 @@
         {% endblock %}
 
         <div class="fos_comment_submit">
-            <button type="button" class="fos_comment_comment_edit_cancel">{% trans from 'FOSCommentBundle' %}fos_comment_comment_new_cancel{% endtrans %}</button>
+            <button type="button" class="fos_comment_comment_edit_cancel">{% trans from 'FOSCommentBundle' %}fos_comment_comment_edit_cancel{% endtrans %}</button>
             {% block fos_comment_form_submit %}
-                <input type="submit" value="{% trans from 'FOSCommentBundle' %}fos_comment_comment_new_submit{% endtrans %}" />
+                <input type="submit" value="{% trans from 'FOSCommentBundle' %}fos_comment_comment_edit_submit{% endtrans %}" />
             {% endblock %}
         </div>
 


### PR DESCRIPTION
@merk @stof I'm not sure what to do with the other languages, I don't speak Russian for example. I've also noticed that some other translation files are not complete too:

https://github.com/FriendsOfSymfony/FOSCommentBundle/blob/master/Resources/translations/FOSCommentBundle.da.yml
vs
https://github.com/FriendsOfSymfony/FOSCommentBundle/blob/master/Resources/translations/FOSCommentBundle.en.yml

etc
