### PR TITLE
CommentExtensionTest::testCanDeleteWhenNoCommentAcl fix

### DIFF
--- a/Tests/Twig/CommentExtensionTest.php
+++ b/Tests/Twig/CommentExtensionTest.php
@@ -157,7 +157,7 @@ class CommentExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $comment = $this->getMock('FOS\CommentBundle\Model\CommentInterface');
         $extension = new CommentExtension();
-        $this->assertTrue($extension->canDeleteComment($comment));
+        $this->assertFalse($extension->canDeleteComment($comment));
     }
 
     public function testCanDeleteWhenCommentAclCanDelete()


### PR DESCRIPTION
Travis is currently failing on `CommentExtensionTest::testCanDeleteWhenNoCommentAc`. There is no way of deleting a comment without a commentAcl, so I assume the test must return false.
