### PR TITLE
Unable to find template "" (getThreadsActions).

### DIFF
--- a/Controller/ThreadController.php
+++ b/Controller/ThreadController.php
@@ -83,6 +83,10 @@ class ThreadController extends Controller
         $ids = $request->query->get('ids');
 
         $threads = $this->container->get('fos_comment.manager.thread')->findThreadsBy(array('id' => $ids));
+        
+        if (0 === count($threads)) {
+            throw new NotFoundHttpException("Not be found threads.");
+        }
 
         $view = View::create()
             ->setData(array('threads' => $threads));


### PR DESCRIPTION
Opening address api/threads without giving any arguments got an error:
```
Unable to find template "".
```
This small commit fix this.