### PR TITLE
Symfony 2.2 compatibility

### DIFF
--- a/Resources/views/Thread/comments.html.twig
+++ b/Resources/views/Thread/comments.html.twig
@@ -14,7 +14,7 @@
 
 {% if depth == 0 %}
     {% if fos_comment_can_comment_thread(thread) %}
-        {% render "FOSCommentBundle:Thread:newThreadComments" with {"id": thread.id} %}
+        {% render url("fos_comment_new_thread_comments", {"id": thread.id}) %}
     {% endif %}
 
     {% if fos_comment_can_edit_thread(thread) %}

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
         "jms/di-extra-bundle": "1.3.*@dev",
         "jms/serializer": "1.0.*@dev",
         "jms/serializer-bundle": "1.0.*@dev",
-        "sensio/framework-extra-bundle": "~2.1",
-        "symfony/symfony": "~2.1.6"
+        "sensio/framework-extra-bundle": ">=2.1,<2.3-dev",
+        "symfony/symfony": ">=2.1,<2.3-dev"
     },
     "suggest": {
         "friendsofsymfony/user-bundle": "Allows for user integration.",


### PR DESCRIPTION
- Render tag changed to the "url" version which works with Symfony 2.2 and 2.1.
- Required Symfony version changed in composer.json to >=2.1,<2.3-dev

Fixes  #336
