### PR TITLE
Updated composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,7 @@
         "friendsofsymfony/rest": "0.8.*@dev",
         "friendsofsymfony/rest-bundle": "0.11.*@dev",
         "jms/di-extra-bundle": "1.3.*@dev",
-        "jms/serializer": "1.0.*@dev",
-        "jms/serializer-bundle": "1.0.*@dev",
+        "jms/serializer-bundle": "0.11.*@dev",
         "sensio/framework-extra-bundle": ">=2.1,<2.3-dev",
         "symfony/symfony": ">=2.1,<2.3-dev"
     },


### PR DESCRIPTION
JMSSerializerBundle seesms to have changed its versioning scheme:
https://github.com/schmittjoh/JMSSerializerBundle/commit/b9e9a6511062b785a96f77a66b506b75fb863ddc

I also removed "jms/serializer" because it is automatically required by "jms/serializer-bundle"
