### PR TITLE
Make dependency on rest-bundle work with new 0.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,9 @@
     "require": {
         "php": ">=5.3.2",
         "friendsofsymfony/rest": "0.8.*@dev",
-        "friendsofsymfony/rest-bundle": "0.11.*@dev",
+        "friendsofsymfony/rest-bundle": ">=0.11,<0.13-dev",
         "jms/di-extra-bundle": "1.3.*@dev",
-        "jms/serializer-bundle": "0.11.*@dev",
+        "jms/serializer-bundle": ">=0.11,<0.13-dev",
         "sensio/framework-extra-bundle": ">=2.1,<2.3-dev",
         "symfony/symfony": ">=2.1,<2.3-dev"
     },


### PR DESCRIPTION
Make dependency on rest-bundle work with new 0.12 version that works with Symfony 2.2.
