### PR TITLE
Trim ajax response string

### DIFF
--- a/Resources/assets/js/comments.js
+++ b/Resources/assets/js/comments.js
@@ -261,7 +261,7 @@
                         {},
                         function(data) {
                             // Post it
-                            var form = $(data).children('form')[0];
+                            var form = $($.trim(data)).children('form')[0];
                             var form_data = $(form).data();
 
                             FOS_COMMENT.post(
@@ -295,13 +295,13 @@
                         {},
                         function(data) {
                             // Post it
-                            var form = $(data).children('form')[0];
+                            var form = $($.trim(data)).children('form')[0];
 
                             FOS_COMMENT.post(
                                 form.action,
                                 FOS_COMMENT.serializeObject(form),
                                 function(data) {
-                                    var commentHtml = $(data);
+                                    var commentHtml = $($.trim(data));
 
                                     var originalComment = $('#' + commentHtml.attr('id'));
 
@@ -375,7 +375,7 @@
         },
 
         editComment: function(commentHtml) {
-            var commentHtml = $(commentHtml);
+            var commentHtml = $($.trim(commentHtml));
             var originalCommentBody = $('#' + commentHtml.attr('id')).children('.fos_comment_comment_body');
 
             originalCommentBody.html(commentHtml.children('.fos_comment_comment_body').html());


### PR DESCRIPTION
The javascript is broken with [jQuery 1.9](http://jquery.com/upgrade-guide/1.9/#jquery-htmlstring-versus-jquery-selectorstring). The problem:

```
jQuery(htmlString) versus jQuery(selectorString)

Prior to 1.9, a string would be considered to be an HTML
string if it had HTML tags anywhere within the string. This
has the potential to cause inadvertent execution of code
and reject valid selector strings. As of 1.9, a string is only
considered to be HTML if it starts with a less-than ("<")
character.
```

To make a long story short, this won't work anymore:

``` js
$('           <div>    </div>          ');
```

Trimming the ajax response string however does the trick:

``` js
$($.trim('           <div>    </div>          '));
```
