### PR TITLE
Trigger fos_comment_new_comment before appendComment

### DIFF
--- a/Resources/assets/js/comments.js
+++ b/Resources/assets/js/comments.js
@@ -136,8 +136,8 @@
                         serializedData,
                         // success
                         function(data, statusCode) {
-                            FOS_COMMENT.appendComment(data, that);
                             that.trigger('fos_comment_new_comment', data);
+                            FOS_COMMENT.appendComment(data, that);
                         },
                         // error
                         function(data, statusCode) {


### PR DESCRIPTION
When doing a reply, the form is removed from the DOM in appendComment. Because of this, fos_comment_new_comment would never trigger for replies (because the form was no longer in the DOM). With the changed order, fos_comment_new_comment now correctly triggers an event.

This might break BC!

Note: fos_comment_submitted_form still won't trigger for replies because at this point of the code, the form is already gone from the DOM.