### PR TITLE
Pass the parent comment together with the children in the template

### DIFF
--- a/Resources/views/Thread/comment_content.html.twig
+++ b/Resources/views/Thread/comment_content.html.twig
@@ -10,7 +10,7 @@
 #}
 
 {% block fos_comment_comment %}
-<div id="fos_comment_{{ comment.id }}" class="fos_comment_comment_show fos_comment_comment_depth_{{ depth }}" {% if parentId is defined %}data-parent="{{ parentId }}"{% endif %}>
+<div id="fos_comment_{{ comment.id }}" class="fos_comment_comment_show fos_comment_comment_depth_{{ depth }}" {% if parent is defined %}data-parent="{{ parent.id }}"{% endif %}>
 
     <div class="fos_comment_comment_metas">
         {% block fos_comment_comment_metas %}
@@ -81,14 +81,13 @@
 
             <div class="fos_comment_comment_replies">
 
-
                 {% if children is defined %}
-                    {% include "FOSCommentBundle:Thread:comments.html.twig" with { "comments": children, "depth": depth + 1, "parentId": comment.id, "view": view } %}
+                    {% include "FOSCommentBundle:Thread:comments.html.twig" with { "comments": children, "depth": depth + 1, "parent": comment, "view": view } %}
                 {% endif %}
 
             </div>
         {% elseif view is sameas('flat') and children is defined %}
-            {% include "FOSCommentBundle:Thread:comments.html.twig" with { "comments": children, "depth": depth + 1, "parentId": comment.id, "view": view } %}
+            {% include "FOSCommentBundle:Thread:comments.html.twig" with { "comments": children, "depth": depth + 1, "parent": comment, "view": view } %}
         {% endif %}
     {% endblock fos_comment_comment_children %}
 


### PR DESCRIPTION
We need more information (like the author) of the parent inside the child comments.
