### PR TITLE
resolved wrong namespace usage

### DIFF
--- a/Controller/ThreadController.php
+++ b/Controller/ThreadController.php
@@ -13,7 +13,7 @@ namespace FOS\CommentBundle\Controller;
 
 use FOS\CommentBundle\Model\CommentInterface;
 use FOS\CommentBundle\Model\ThreadInterface;
-use FOS\Rest\Util\Codes;
+use FOS\RestBundle\Util\Codes;
 use FOS\RestBundle\View\RouteRedirectView;
 use FOS\RestBundle\View\View;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;


### PR DESCRIPTION
Hi,

I had an error when posting a comment with only one character (FatalErrorException: Error: Class 'FOS\Rest\Util\Codes' not found in /Applications/MAMP/htdocs/Creapills/vendor/friendsofsymfony/comment-bundle/FOS/CommentBundle/Controller/ThreadController.php line 607), to fix this i updated the namespace of the Class Codes used in the Thread Controller.
