### PR TITLE
Add comment on needed format_listener rule after upgrading

### DIFF
--- a/UPDATE.markdown
+++ b/UPDATE.markdown
@@ -1,3 +1,15 @@
+2.0.x:
+
+ * The dependencies to FOS RestBundle have changed and as a result, you need to ensure that you have defined 
+   a format_listener rule for comment-bundle, for example:
+
+```yaml
+fos_rest:
+   format_listener:
+         rules:
+           - { path: '^/comments', priorities: ['json', 'html'], fallback_format: json }
+```
+
 2.0.4 to 2.0.5
  * Editing is more robust and works even if you change the structure of the HTML
    code. If you have customised the "comment_content.html.twig" you might need to


### PR DESCRIPTION
After upgrading to FOSRestBundle  v1.0 you need to set a format_listener rule.
