### PR TITLE
Throw http exception if thread is not commentable

### DIFF
--- a/Controller/ThreadController.php
+++ b/Controller/ThreadController.php
@@ -21,6 +21,7 @@ use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -471,6 +472,10 @@ class ThreadController extends Controller
         $thread = $this->container->get('fos_comment.manager.thread')->findThreadById($id);
         if (!$thread) {
             throw new NotFoundHttpException(sprintf('Thread with identifier of "%s" does not exist', $id));
+        }
+        
+        if (!$thread->isCommentable()) {
+            throw new AccessDeniedHttpException(sprintf('Thread "%s" is not commentable', $id));
         }
 
         $parent = $this->getValidCommentParent($thread, $request->query->get('parentId'));


### PR DESCRIPTION
If a comment is added to a thread which was just set as "not commentable", a LogicException is thrown by the listener, resulting in a 500 internal server error.

This PR checks if the thread is commentable and throws a proper access denied http exception in the controller.
