### PR TITLE
PhpDoc fixes for all the commentManager related classes

### DIFF
--- a/Acl/AclCommentManager.php
+++ b/Acl/AclCommentManager.php
@@ -179,7 +179,8 @@ class AclCommentManager implements CommentManagerInterface
      * Iterates over a comment tree array and makes sure all comments
      * have appropriate view permissions.
      *
-     * @param  array   $comments A comment tree
+     * @param array $comments A comment tree
+     *
      * @return boolean
      */
     protected function authorizeViewCommentTree(array $comments)

--- a/Document/CommentManager.php
+++ b/Document/CommentManager.php
@@ -43,10 +43,10 @@ class CommentManager extends BaseCommentManager
     /**
      * Constructor.
      *
-     * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher
-     * @param \FOS\CommentBundle\Sorting\SortingFactory                   $factory
-     * @param \Doctrine\ODM\MongoDB\DocumentManager                       $dm
-     * @param string                                                      $class
+     * @param EventDispatcherInterface $dispatcher
+     * @param SortingFactory           $factory
+     * @param DocumentManager          $dm
+     * @param string                   $class
      */
     public function __construct(EventDispatcherInterface $dispatcher, SortingFactory $factory, DocumentManager $dm, $class)
     {
@@ -60,11 +60,7 @@ class CommentManager extends BaseCommentManager
     }
 
     /**
-     * Returns a flat array of comments of a specific thread.
-     *
-     * @param  ThreadInterface $thread
-     * @param  integer         $depth
-     * @return array           of ThreadInterface
+     * {@inheritdoc}
      */
     public function findCommentsByThread(ThreadInterface $thread, $depth = null, $sorterAlias = null)
     {
@@ -93,11 +89,7 @@ class CommentManager extends BaseCommentManager
     }
 
     /**
-     * Returns the requested comment tree branch
-     *
-     * @param  integer $commentId
-     * @param  string  $sorter
-     * @return array   See findCommentsByThread
+     * {@inheritdoc}
      */
     public function findCommentTreeByCommentId($commentId, $sorter = null)
     {
@@ -121,9 +113,7 @@ class CommentManager extends BaseCommentManager
     }
 
     /**
-     * Adds a comment
-     *
-     * @param CommentInterface $comment
+     * {@inheritdoc}
      */
     protected function doSaveComment(CommentInterface $comment)
     {
@@ -133,17 +123,15 @@ class CommentManager extends BaseCommentManager
     }
 
     /**
-     * Find one comment by its ID
-     *
-     * @return Comment or null
-     **/
+     * {@inheritdoc}
+     */
     public function findCommentById($id)
     {
         return $this->repository->find($id);
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function isNewComment(CommentInterface $comment)
     {
@@ -151,10 +139,8 @@ class CommentManager extends BaseCommentManager
     }
 
     /**
-     * Returns the fully qualified comment thread class name
-     *
-     * @return string
-     **/
+     * {@inheritdoc}
+     */
     public function getClass()
     {
         return $this->class;

--- a/Entity/CommentManager.php
+++ b/Entity/CommentManager.php
@@ -17,6 +17,7 @@ use FOS\CommentBundle\Model\ThreadInterface;
 use FOS\CommentBundle\Model\CommentInterface;
 use FOS\CommentBundle\Sorting\SortingFactory;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Doctrine\ORM\EntityRepository;
 
 /**
  * Default ORM CommentManager.
@@ -43,10 +44,10 @@ class CommentManager extends BaseCommentManager
     /**
      * Constructor.
      *
-     * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher
-     * @param \FOS\CommentBundle\Sorting\SortingFactory                   $factory
-     * @param \Doctrine\ORM\EntityManager                                 $em
-     * @param string                                                      $class
+     * @param EventDispatcherInterface $dispatcher
+     * @param SortingFactory           $factory
+     * @param EntityManager            $em
+     * @param string                   $class
      */
     public function __construct(EventDispatcherInterface $dispatcher, SortingFactory $factory, EntityManager $em, $class)
     {
@@ -60,11 +61,7 @@ class CommentManager extends BaseCommentManager
     }
 
     /**
-     * Returns a flat array of comments of a specific thread.
-     *
-     * @param  ThreadInterface $thread
-     * @param  integer         $depth
-     * @return array           of ThreadInterface
+     * {@inheritdoc}
      */
     public function findCommentsByThread(ThreadInterface $thread, $depth = null, $sorterAlias = null)
     {
@@ -96,11 +93,7 @@ class CommentManager extends BaseCommentManager
     }
 
     /**
-     * Returns the requested comment tree branch
-     *
-     * @param  integer $commentId
-     * @param  string  $sorter
-     * @return array   See findCommentTreeByThread
+     * {@inheritdoc}
      */
     public function findCommentTreeByCommentId($commentId, $sorter = null)
     {
@@ -136,17 +129,15 @@ class CommentManager extends BaseCommentManager
     }
 
     /**
-     * Find one comment by its ID
-     *
-     * @return Comment or null
-     **/
+     * {@inheritdoc}
+     */
     public function findCommentById($id)
     {
         return $this->repository->find($id);
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function isNewComment(CommentInterface $comment)
     {
@@ -154,10 +145,8 @@ class CommentManager extends BaseCommentManager
     }
 
     /**
-     * Returns the fully qualified comment thread class name
-     *
-     * @return string
-     **/
+     * {@inheritdoc}
+     */
     public function getClass()
     {
         return $this->class;

--- a/Model/CommentManager.php
+++ b/Model/CommentManager.php
@@ -33,15 +33,15 @@ abstract class CommentManager implements CommentManagerInterface
     protected $sortingFactory;
 
     /**
-     * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+     * @var EventDispatcherInterface
      */
     protected $dispatcher;
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher
-     * @param \FOS\CommentBundle\Sorting\SortingFactory                   $factory
+     * @param EventDispatcherInterface $dispatcher A dispatcher instance.
+     * @param SortingFactory           $factory    A factory instance.
      */
     public function __construct(EventDispatcherInterface $dispatcher, SortingFactory $factory)
     {
@@ -50,9 +50,7 @@ abstract class CommentManager implements CommentManagerInterface
     }
 
     /**
-     * Returns an empty comment instance
-     *
-     * @return Comment
+     * {@inheritdoc}
      */
     public function createComment(ThreadInterface $thread, CommentInterface $parent = null)
     {
@@ -71,30 +69,8 @@ abstract class CommentManager implements CommentManagerInterface
         return $comment;
     }
 
-    /*
-     * Returns all thread comments in a nested array
-     * Will typically be used when it comes to display the comments.
-     *
-     * @param  ThreadInterface $thread
-     * @param  string          $sorter
-     * @param  integer         $depth
-     * @return array(
-     *     0 => array(
-     *         'comment' => CommentInterface,
-     *         'children' => array(
-     *             0 => array (
-     *                 'comment' => CommentInterface,
-     *                 'children' => array(...)
-     *             ),
-     *             1 => array (
-     *                 'comment' => CommentInterface,
-     *                 'children' => array(...)
-     *             )
-     *         )
-     *     ),
-     *     1 => array(
-     *         ...
-     *     )
+    /**
+     * {@inheritdoc}
      */
     public function findCommentTreeByThread(ThreadInterface $thread, $sorter = null, $depth = null)
     {
@@ -105,15 +81,16 @@ abstract class CommentManager implements CommentManagerInterface
     }
 
     /**
-     * Organises a flat array of comments into a Tree structure. For
-     * organising comment branches of a Tree, certain parents which
-     * have not been fetched should be passed in as an array to
-     * $ignoreParents.
+     * Organises a flat array of comments into a Tree structure.
      *
-     * @param  array       $comments      An array of comments to organise
-     * @param  string|null $sorter        The sorter to use for sorting the tree
-     * @param  array|null  $ignoreParents An array of parents to ignore
-     * @return array       A tree of comments
+     * For organising comment branches of a Tree, certain parents which
+     * have not been fetched should be passed in as an array to $ignoreParents.
+     *
+     * @param CommentInterface[]      $comments      An array of comments to organise
+     * @param SortingInterface        $sorter        The sorter to use for sorting the tree
+     * @param CommentInterface[]|null $ignoreParents An array of parents to ignore
+     *
+     * @return array A tree of comments
      */
     protected function organiseComments($comments, SortingInterface $sorter, $ignoreParents = null)
     {
@@ -141,12 +118,7 @@ abstract class CommentManager implements CommentManagerInterface
     }
 
     /**
-     * Saves a comment to the persistence backend used. Each backend
-     * must implement the abstract doSaveComment method which will
-     * perform the saving of the comment to the backend.
-     *
-     * @param  CommentInterface         $comment
-     * @throws InvalidArgumentException when the comment does not have a thread.
+     * {@inheritdoc}
      */
     public function saveComment(CommentInterface $comment)
     {
@@ -172,7 +144,6 @@ abstract class CommentManager implements CommentManagerInterface
     /**
      * Performs the persistence of a comment.
      *
-     * @abstract
      * @param CommentInterface $comment
      */
     abstract protected function doSaveComment(CommentInterface $comment);

--- a/Model/CommentManagerInterface.php
+++ b/Model/CommentManagerInterface.php
@@ -12,8 +12,9 @@
 namespace FOS\CommentBundle\Model;
 
 /**
- * Interface to be implemented by comment managers. This adds an additional level
- * of abstraction between your application, and the actual repository.
+ * Interface to be implemented by comment managers.
+ *
+ * This adds an additional level of abstraction between your application, and the actual repository.
  *
  * All changes to comments should happen through this interface.
  *
@@ -23,28 +24,31 @@ namespace FOS\CommentBundle\Model;
 interface CommentManagerInterface
 {
     /**
-     * Returns a flat array of comments with the specified thread.
+     * Returns a flat array of comments from the specified thread.
      *
      * The sorter parameter should be left alone if you are sorting in the
      * tree methods.
      *
-     * @param  ThreadInterface $thread
-     * @param  integer         $depth
-     * @param  string          $sorterAlias
-     * @return array           of CommentInterface
+     * @param ThreadInterface $thread
+     * @param integer|null    $depth
+     * @param string|null     $sorterAlias
+     *
+     * @return CommentInterface[] An array of commentInterfaces
      */
     public function findCommentsByThread(ThreadInterface $thread, $depth = null, $sorterAlias = null);
 
-    /*
-     * Returns all thread comments in a nested array
+    /**
+     * Returns all thread comments in a nested array.
+     *
      * Will typically be used when it comes to display the comments.
      *
      * Will query for an additional level of depth when provided
      * so templates can determine to display a 'load more comments' link.
      *
-     * @param  ThreadInterface $thread
-     * @param  string          $sorter The sorter to use
-     * @param  integer         $depth
+     * @param ThreadInterface $thread      The thread for whom we want to find comments for.
+     * @param string|null     $sorterAlias Optional name of the sorter to use.
+     * @param integer|null    $depth       The depth
+     *
      * @return array(
      *     0 => array(
      *         'comment' => CommentInterface,
@@ -63,49 +67,55 @@ interface CommentManagerInterface
      *         ...
      *     )
      */
-    public function findCommentTreeByThread(ThreadInterface $thread, $sorter = null, $depth = null);
+    public function findCommentTreeByThread(ThreadInterface $thread, $sorterAlias = null, $depth = null);
 
     /**
      * Returns a partial comment tree based on a specific parent commentId.
      *
-     * @param  integer $commentId
-     * @param  string  $sorter    The sorter to use
-     * @return array   see findCommentTreeByThread()
+     * @param mixed       $commentId   The unique comment identifier
+     * @param string|null $sorterAlias Name of the optional sorter
+     *
+     * @return array See findCommentTreeByThread()
      */
-    public function findCommentTreeByCommentId($commentId, $sorter = null);
+    public function findCommentTreeByCommentId($commentId, $sorterAlias = null);
 
     /**
-     * Saves a comment.
+     * Saves a comment to the persistence backend used.
      *
      * @param CommentInterface $comment
      */
     public function saveComment(CommentInterface $comment);
 
     /**
-     * Find one comment by its ID.
+     * Finds a comment by it's unique id.
      *
-     * @return Comment or null
+     * @param mixed $id The unique comment identifier.
+     *
+     * @return CommentInterface|null The comment or null when no comment found
      */
     public function findCommentById($id);
 
     /**
-     * Creates an empty comment instance.
+     * Creates a new comment object.
      *
-     * @return Comment
+     * @param ThreadInterface       $thread A thread instance
+     * @param CommentInterface|null $parent The parent comment or null if no parent comment
+     *
+     * @return CommentInterface The created comment.
      */
-    public function createComment(ThreadInterface $thread, CommentInterface $comment = null);
+    public function createComment(ThreadInterface $thread, CommentInterface $parent = null);
 
     /**
      * Checks if the comment was already persisted before, or if it's a new one.
      *
      * @param CommentInterface $comment
      *
-     * @return boolean True, if it's a new comment
+     * @return boolean true if it's a new comment, false otherwise
      */
     public function isNewComment(CommentInterface $comment);
 
     /**
-     * Returns the comment fully qualified class name.
+     * Returns the fully qualified comment class name
      *
      * @return string
      */


### PR DESCRIPTION
Greetings,

While working with PHPStorm I noticed some PhpDoc problems with the comment manager classes.  So I decided to clean them up.
- Removed all the conflicting phpdoc in the classes with `{@inheritdoc}`.
- This also fixed some errors like https://github.com/FriendsOfSymfony/FOSCommentBundle/blob/master/Entity/CommentManager.php#L67 (returns comments, not threads)
- Improved IDE autocompletion by replacing things like `@return array An array of CommentInterfaces` with `@return CommentInterface[] An array of CommentInterfaces`.
