### PR TITLE
generatedValue changed to GeneratedValue

### DIFF
--- a/Resources/doc/12a-mapping_orm.md
+++ b/Resources/doc/12a-mapping_orm.md
@@ -24,7 +24,7 @@ class Vote extends BaseVote
     /**
      * @ORM\Id
      * @ORM\Column(type="integer")
-     * @ORM\generatedValue(strategy="AUTO")
+     * @ORM\GeneratedValue(strategy="AUTO")
      */
     protected $id;
 


### PR DESCRIPTION
[Doctrine\Common\Annotations\AnnotationException]  
  [Semantical Error] The annotation "@Doctrine\ORM\Mapping\generatedValue" in property XXX\CommentBundle\Entity\Vote::$id does  
  not exist, or could not be auto-loaded.
