### PR TITLE
Update to the new ExecutionContextInterface

### DIFF
--- a/Model/Vote.php
+++ b/Model/Vote.php
@@ -87,12 +87,15 @@ abstract class Vote implements VoteInterface
     /**
      * {@inheritdoc}
      */
-    public function isVoteValid(ExecutionContext $context)
+    public function isVoteValid(ExecutionContextInterface $context)
     {
         if (!$this->checkValue($this->value)) {
             $message = 'A vote cannot have a 0 value';
             $propertyPath = $context->getPropertyPath() . '.value';
-            $context->addViolationAtPath($propertyPath, $message);
+
+            $context->buildViolation($message)
+                ->atPath($propertyPath)
+                ->addViolation();
         }
     }
 

--- a/Model/Vote.php
+++ b/Model/Vote.php
@@ -13,7 +13,7 @@ namespace FOS\CommentBundle\Model;
 
 use DateTime;
 
-use Symfony\Component\Validator\ExecutionContext;
+use Symfony\Component\Validator\ExecutionContextInterface;
 
 /**
  * Storage agnostic vote object - Requires FOS\UserBundle
@@ -92,10 +92,7 @@ abstract class Vote implements VoteInterface
         if (!$this->checkValue($this->value)) {
             $message = 'A vote cannot have a 0 value';
             $propertyPath = $context->getPropertyPath() . '.value';
-
-            $context->buildViolation($message)
-                ->atPath($propertyPath)
-                ->addViolation();
+            $context->addViolationAt($propertyPath, $message);
         }
     }
 

--- a/Model/VoteInterface.php
+++ b/Model/VoteInterface.php
@@ -11,7 +11,7 @@
 
 namespace FOS\CommentBundle\Model;
 
-use Symfony\Component\Validator\ExecutionContext;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
  * Methods a vote should implement.
@@ -49,7 +49,7 @@ interface VoteInterface
     public function getCreatedAt();
 
     /**
-     * @param ExecutionContext $context
+     * @param ExecutionContextInterface $context
      */
-    public function isVoteValid(ExecutionContext $context);
+    public function isVoteValid(ExecutionContextInterface $context);
 }

--- a/Model/VoteInterface.php
+++ b/Model/VoteInterface.php
@@ -11,7 +11,7 @@
 
 namespace FOS\CommentBundle\Model;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\ExecutionContextInterface;
 
 /**
  * Methods a vote should implement.


### PR DESCRIPTION
I started using this bundle with Symfony 2.5 and realized that the validation portion of the bundle was no longer working as the old ExecutionContext is deprecated (and we weren't using an interface).

