### PR TITLE
The template expects commentId to be set.

### DIFF
--- a/Controller/ThreadController.php
+++ b/Controller/ThreadController.php
@@ -802,6 +802,7 @@ class ThreadController extends Controller
             ->setData(array(
                 'form' => $form,
                 'id' => $id,
+                'commentId' => $form->getData()->getId(),
                 'value' => $form->getData()->getState(),
             ))
             ->setTemplate(new TemplateReference('FOSCommentBundle', 'Thread', 'comment_remove'));


### PR DESCRIPTION
This solves a 500 error.
