### PR TITLE
Update composer.json to use

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": ">=5.3.2",
         "friendsofsymfony/rest-bundle": "~1.0",
-        "jms/serializer-bundle": "~0.11",
+        "jms/serializer-bundle": "~1.0.0",
         "symfony/framework-bundle": "~2.3",
         "symfony/security-bundle": "~2.3",
         "symfony/yaml": "~2.3",


### PR DESCRIPTION
some popular 3rd party bundles require `jms/serializer-bundle: ~1.0.0`, but `FOSCommentBundle`'s old `~0.11` requirement results in an unresolvable dependency tree conflict. There are only bugfixes and no BC breaks between `0.13` (latest 0.x version) and `1.0.0`, so I suggest updating the requirement to `~1.0.0`