### PR TITLE
[Feedback] CommentForm fix

### DIFF
--- a/Controller/ThreadController.php
+++ b/Controller/ThreadController.php
@@ -356,7 +356,7 @@ class ThreadController extends Controller
             throw new NotFoundHttpException(sprintf("No comment with id '%s' found for thread with id '%s'", $commentId, $id));
         }
 
-        $form = $this->container->get('fos_comment.form_factory.comment')->createForm();
+        $form = $this->container->get('fos_comment.form_factory.comment')->createForm(null, array('method' => 'PUT'));
         $form->setData($comment);
         $form->handleRequest($request);
 
@@ -476,7 +476,7 @@ class ThreadController extends Controller
         $commentManager = $this->container->get('fos_comment.manager.comment');
         $comment = $commentManager->createComment($thread, $parent);
 
-        $form = $this->container->get('fos_comment.form_factory.comment')->createForm();
+        $form = $this->container->get('fos_comment.form_factory.comment')->createForm(null, array('method' => 'POST'));
         $form->setData($comment);
         $form->handleRequest($request);
 

--- a/FormFactory/CommentFormFactory.php
+++ b/FormFactory/CommentFormFactory.php
@@ -52,13 +52,11 @@ class CommentFormFactory implements CommentFormFactoryInterface
     }
 
     /**
-     * Creates a new form.
-     *
-     * @return FormInterface
+     * {@inheritdoc}
      */
-    public function createForm()
+    public function createForm($data = null, $options = array())
     {
-        $builder = $this->formFactory->createNamedBuilder($this->name, $this->type);
+        $builder = $this->formFactory->createNamedBuilder($this->name, $this->type, $data, $options);
 
         return $builder->getForm();
     }

--- a/FormFactory/CommentFormFactoryInterface.php
+++ b/FormFactory/CommentFormFactoryInterface.php
@@ -23,7 +23,10 @@ interface CommentFormFactoryInterface
     /**
      * Creates a comment form
      *
+     * @param mixed $method
+     * @param array $options
+     *
      * @return FormInterface
      */
-    public function createForm();
+    public function createForm($data = null, $options = array());
 }


### PR DESCRIPTION
The comment form method can be either POST or PUT. The form won't validate without configuring the method in `CommentFormFactory::createForm()` because POST is default.

I'm not sure how to properly fix this: the proposed solution would introduce a BC break.

Ping @stof 