### PR TITLE
Allow intermediary DOM parents of .fos_comment_comment_replies

### DIFF
--- a/Resources/assets/js/comments.js
+++ b/Resources/assets/js/comments.js
@@ -353,7 +353,7 @@
                 var reply_button_holder = form.closest('.fos_comment_comment_reply');
 
                 var comment_element = form.closest('.fos_comment_comment_show')
-                    .children('.fos_comment_comment_replies');
+                    .find('.fos_comment_comment_replies:first');
 
                 reply_button_holder.removeClass('fos_comment_replying');
 


### PR DESCRIPTION
When modifying the Twig templates and placing additional DOM parents between the .fos_comment_comment_replies and .fos_comment_comment_show elements, the code for appending a new comment stops working because it expects to find it as a direct child.

The following code will allow searching deeper into the DOM tree node if there is more markup in between.