### PR TITLE
Fix a regression.

### DIFF
--- a/Controller/ThreadController.php
+++ b/Controller/ThreadController.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 
 define('HTTP_BAD_REQUEST', 400);


### PR DESCRIPTION
This commit https://github.com/FriendsOfSymfony/FOSCommentBundle/commit/ba54b4327b403748b359b9b139be1d58363f2266
removed
``` use Symfony\Component\Validator\Validator\ValidatorInterface; ```

That import is needed in Symfony > 2.5 and Symfony 3,  or the if ( https://github.com/FriendsOfSymfony/FOSCommentBundle/blob/master/Controller/ThreadController.php#L402 ) always fail and this is the result:

``` 
CRITICAL - Uncaught PHP Exception Symfony\Component\Debug\Exception\ContextErrorException: "Catchable Fatal Error: Argument 1 passed to Symfony\Component\Validator\Mapping\GenericMetadata::addConstraint() must be an instance of Symfony\Component\Validator\Constraint, string given, called in \vendor\symfony\symfony\src\Symfony\Component\Validator\Mapping\GenericMetadata.php on line 167 and defined" at \vendor\symfony\symfony\src\Symfony\Component\Validator\Mapping\GenericMetadata.php line 126 
```