### PR TITLE
Add suffixName on Form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Tests/autoload.php
 Tests/Functional/app/Behat/nginx.conf
 Tests/Functional/web/bundles
 vendor
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ Tests/autoload.php
 Tests/Functional/app/Behat/nginx.conf
 Tests/Functional/web/bundles
 vendor
-.idea/

--- a/Controller/ThreadController.php
+++ b/Controller/ThreadController.php
@@ -139,7 +139,7 @@ class ThreadController extends Controller
 
         $thread->setCommentable($request->query->get('value', 1));
 
-        $form = $this->container->get('fos_comment.form_factory.commentable_thread')->createForm();
+        $form = $this->container->get('fos_comment.form_factory.commentable_thread')->createForm($thread->getId());
         $form->setData($thread);
 
         $view = View::create()
@@ -166,7 +166,7 @@ class ThreadController extends Controller
             throw new NotFoundHttpException(sprintf("Thread with id '%s' could not be found.", $id));
         }
 
-        $form = $this->container->get('fos_comment.form_factory.commentable_thread')->createForm();
+        $form = $this->container->get('fos_comment.form_factory.commentable_thread')->createForm($thread->getId());
         $form->setData($thread);
         $form->handleRequest($request);
 
@@ -198,7 +198,7 @@ class ThreadController extends Controller
 
         $parent = $this->getValidCommentParent($thread, $request->query->get('parentId'));
 
-        $form = $this->container->get('fos_comment.form_factory.comment')->createForm();
+        $form = $this->container->get('fos_comment.form_factory.comment')->createForm(null, array(), $thread->getId());
         $form->setData($comment);
 
         $view = View::create()
@@ -262,7 +262,7 @@ class ThreadController extends Controller
             throw new NotFoundHttpException(sprintf("No comment with id '%s' found for thread with id '%s'", $commentId, $id));
         }
 
-        $form = $this->container->get('fos_comment.form_factory.delete_comment')->createForm();
+        $form = $this->container->get('fos_comment.form_factory.delete_comment')->createForm($comment->getId());
         $comment->setState($request->query->get('value', $comment::STATE_DELETED));
 
         $form->setData($comment);
@@ -293,7 +293,7 @@ class ThreadController extends Controller
             throw new NotFoundHttpException(sprintf("No comment with id '%s' found for thread with id '%s'", $commentId, $id));
         }
 
-        $form = $this->container->get('fos_comment.form_factory.delete_comment')->createForm();
+        $form = $this->container->get('fos_comment.form_factory.delete_comment')->createForm($comment->getId());
         $form->setData($comment);
         $form->handleRequest($request);
 
@@ -323,7 +323,7 @@ class ThreadController extends Controller
             throw new NotFoundHttpException(sprintf("No comment with id '%s' found for thread with id '%s'", $commentId, $id));
         }
 
-        $form = $this->container->get('fos_comment.form_factory.comment')->createForm();
+        $form = $this->container->get('fos_comment.form_factory.comment')->createForm(null, array(), $thread->getId());
         $form->setData($comment);
 
         $view = View::create()
@@ -356,7 +356,7 @@ class ThreadController extends Controller
             throw new NotFoundHttpException(sprintf("No comment with id '%s' found for thread with id '%s'", $commentId, $id));
         }
 
-        $form = $this->container->get('fos_comment.form_factory.comment')->createForm(null, array('method' => 'PUT'));
+        $form = $this->container->get('fos_comment.form_factory.comment')->createForm(null, array('method' => 'PUT'), $thread->getId());
         $form->setData($comment);
         $form->handleRequest($request);
 
@@ -476,7 +476,7 @@ class ThreadController extends Controller
         $commentManager = $this->container->get('fos_comment.manager.comment');
         $comment = $commentManager->createComment($thread, $parent);
 
-        $form = $this->container->get('fos_comment.form_factory.comment')->createForm(null, array('method' => 'POST'));
+        $form = $this->container->get('fos_comment.form_factory.comment')->createForm(null, array('method' => 'POST'), $thread->getId());
         $form->setData($comment);
         $form->handleRequest($request);
 
@@ -536,7 +536,7 @@ class ThreadController extends Controller
         $vote = $this->container->get('fos_comment.manager.vote')->createVote($comment);
         $vote->setValue($request->query->get('value', 1));
 
-        $form = $this->container->get('fos_comment.form_factory.vote')->createForm();
+        $form = $this->container->get('fos_comment.form_factory.vote')->createForm($comment->getId());
         $form->setData($vote);
 
         $view = View::create()
@@ -571,7 +571,7 @@ class ThreadController extends Controller
         $voteManager = $this->container->get('fos_comment.manager.vote');
         $vote = $voteManager->createVote($comment);
 
-        $form = $this->container->get('fos_comment.form_factory.vote')->createForm();
+        $form = $this->container->get('fos_comment.form_factory.vote')->createForm($comment->getId());
         $form->setData($vote);
         $form->handleRequest($request);
 

--- a/FormFactory/CommentFormFactory.php
+++ b/FormFactory/CommentFormFactory.php
@@ -11,7 +11,6 @@
 
 namespace FOS\CommentBundle\FormFactory;
 
-use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 
 /**
@@ -41,22 +40,25 @@ class CommentFormFactory implements CommentFormFactoryInterface
      * Constructor.
      *
      * @param FormFactoryInterface $formFactory
-     * @param string               $type
-     * @param string               $name
+     * @param string $type
+     * @param string $name
      */
     public function __construct(FormFactoryInterface $formFactory, $type, $name)
     {
         $this->formFactory = $formFactory;
-        $this->type        = $type;
-        $this->name        = $name;
+        $this->type = $type;
+        $this->name = $name;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function createForm($data = null, $options = array())
+    public function createForm($data = null, $options = array(), $name_suffix = null)
     {
-        $builder = $this->formFactory->createNamedBuilder($this->name, $this->type, $data, $options);
+        if (empty($name_suffix)) {
+            $name_suffix = '';
+        }
+        $builder = $this->formFactory->createNamedBuilder($this->name . $name_suffix, $this->type);
 
         return $builder->getForm();
     }

--- a/FormFactory/CommentFormFactoryInterface.php
+++ b/FormFactory/CommentFormFactoryInterface.php
@@ -23,10 +23,11 @@ interface CommentFormFactoryInterface
     /**
      * Creates a comment form
      *
-     * @param mixed $method
-     * @param array $options
+     * @param mixed $data
+     * @param array $options => method
+     * @param string $name_suffix
      *
      * @return FormInterface
      */
-    public function createForm($data = null, $options = array());
+    public function createForm($data = null, $options = array(), $name_suffix = null);
 }

--- a/FormFactory/CommentableThreadFormFactory.php
+++ b/FormFactory/CommentableThreadFormFactory.php
@@ -11,8 +11,8 @@
 
 namespace FOS\CommentBundle\FormFactory;
 
-use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 
 /**
  * CommentableThreadForm factory class.
@@ -38,14 +38,14 @@ class CommentableThreadFormFactory implements CommentableThreadFormFactoryInterf
      * Constructor.
      *
      * @param FormFactoryInterface $formFactory
-     * @param string               $type
-     * @param string               $name
+     * @param string $type
+     * @param string $name
      */
     public function __construct(FormFactoryInterface $formFactory, $type, $name)
     {
         $this->formFactory = $formFactory;
-        $this->type        = $type;
-        $this->name        = $name;
+        $this->type = $type;
+        $this->name = $name;
     }
 
     /**
@@ -53,9 +53,13 @@ class CommentableThreadFormFactory implements CommentableThreadFormFactoryInterf
      *
      * @return FormInterface
      */
-    public function createForm()
+    public function createForm($name_suffix = null)
     {
-        $builder = $this->formFactory->createNamedBuilder($this->name, $this->type, null, array('validation_groups' => array('OpenThread'), 'method' => 'PATCH'));
+        if (empty($name_suffix)) {
+            $name_suffix = '';
+        }
+        $builder = $this->formFactory->createNamedBuilder($this->name . $name_suffix, $this->type, null, array('validation_groups' => array('OpenThread'), 'method' => 'PATCH'));
+
 
         return $builder->getForm();
     }

--- a/FormFactory/CommentableThreadFormFactoryInterface.php
+++ b/FormFactory/CommentableThreadFormFactoryInterface.php
@@ -21,7 +21,8 @@ interface CommentableThreadFormFactoryInterface
     /**
      * Creates a open thread form
      *
+     * @param $name_suffix string the suffix to name the form
      * @return FormInterface
      */
-    public function createForm();
+    public function createForm($name_suffix = null);
 }

--- a/FormFactory/DeleteCommentFormFactory.php
+++ b/FormFactory/DeleteCommentFormFactory.php
@@ -11,8 +11,8 @@
 
 namespace FOS\CommentBundle\FormFactory;
 
-use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 
 /**
  * DeleteCommentFormFactory factory class.
@@ -38,14 +38,14 @@ class DeleteCommentFormFactory implements DeleteCommentFormFactoryInterface
      * Constructor.
      *
      * @param FormFactoryInterface $formFactory
-     * @param string               $type
-     * @param string               $name
+     * @param string $type
+     * @param string $name
      */
     public function __construct(FormFactoryInterface $formFactory, $type, $name)
     {
         $this->formFactory = $formFactory;
-        $this->type        = $type;
-        $this->name        = $name;
+        $this->type = $type;
+        $this->name = $name;
     }
 
     /**
@@ -53,9 +53,12 @@ class DeleteCommentFormFactory implements DeleteCommentFormFactoryInterface
      *
      * @return FormInterface
      */
-    public function createForm()
+    public function createForm($name_suffix = null)
     {
-        $builder = $this->formFactory->createNamedBuilder($this->name, $this->type, null, array('method' => 'PATCH'));
+        if (empty($name_suffix)) {
+            $name_suffix = '';
+        }
+        $builder = $this->formFactory->createNamedBuilder($this->name . $name_suffix, $this->type, null, array('method' => 'PATCH'));
 
         return $builder->getForm();
     }

--- a/FormFactory/DeleteCommentFormFactoryInterface.php
+++ b/FormFactory/DeleteCommentFormFactoryInterface.php
@@ -23,5 +23,5 @@ interface DeleteCommentFormFactoryInterface
      *
      * @return FormInterface
      */
-    public function createForm();
+    public function createForm($name_suffix = null);
 }

--- a/FormFactory/ThreadFormFactory.php
+++ b/FormFactory/ThreadFormFactory.php
@@ -11,8 +11,8 @@
 
 namespace FOS\CommentBundle\FormFactory;
 
-use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 
 /**
  * ThreadForm factory class.
@@ -38,14 +38,14 @@ class ThreadFormFactory implements ThreadFormFactoryInterface
      * Constructor.
      *
      * @param FormFactoryInterface $formFactory
-     * @param string               $type
-     * @param string               $name
+     * @param string $type
+     * @param string $name
      */
     public function __construct(FormFactoryInterface $formFactory, $type, $name)
     {
         $this->formFactory = $formFactory;
-        $this->type        = $type;
-        $this->name        = $name;
+        $this->type = $type;
+        $this->name = $name;
     }
 
     /**

--- a/FormFactory/VoteFormFactory.php
+++ b/FormFactory/VoteFormFactory.php
@@ -11,8 +11,8 @@
 
 namespace FOS\CommentBundle\FormFactory;
 
-use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 
 /**
  * VoteForm factory class.
@@ -41,24 +41,28 @@ class VoteFormFactory implements VoteFormFactoryInterface
      * Constructor.
      *
      * @param FormFactoryInterface $formFactory
-     * @param string               $type
-     * @param string               $name
+     * @param string $type
+     * @param string $name
      */
     public function __construct(FormFactoryInterface $formFactory, $type, $name)
     {
         $this->formFactory = $formFactory;
-        $this->type        = $type;
-        $this->name        = $name;
+        $this->type = $type;
+        $this->name = $name;
     }
 
     /**
      * Creates a new form.
      *
+     * @param $name_suffix string Suffix of the form name
      * @return FormInterface
      */
-    public function createForm()
+    public function createForm($name_suffix = null)
     {
-        $builder = $this->formFactory->createNamedBuilder($this->name, $this->type);
+        if (empty($name_suffix)) {
+            $name_suffix = '';
+        }
+        $builder = $this->formFactory->createNamedBuilder($this->name . $name_suffix, $this->type);
 
         return $builder->getForm();
     }

--- a/FormFactory/VoteFormFactoryInterface.php
+++ b/FormFactory/VoteFormFactoryInterface.php
@@ -23,7 +23,8 @@ interface VoteFormFactoryInterface
     /**
      * Creates a comment form
      *
+     * @param $name_suffix string Suffix of the form name
      * @return FormInterface
      */
-    public function createForm();
+    public function createForm($name_suffix = null);
 }

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,11 @@
 {
     "name": "friendsofsymfony/comment-bundle",
     "type": "symfony-bundle",
-    "description": "This Bundle provides threaded comment functionality for Symfony 3 applications",
+    "description": "This Bundle provides threaded comment functionality for Symfony2 applications",
     "keywords": ["comment", "threads", "forum"],
     "homepage": "http://friendsofsymfony.github.com",
     "license": "MIT",
     "authors": [
-        {
-            "name": "Flavien Audin"
-        },
         {
             "name": "Tim Nagel",
             "email": "tim@nagel.com.au"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "flavienaudin/comment-bundle",
+    "name": "friendsofsymfony/comment-bundle",
     "type": "symfony-bundle",
     "description": "This Bundle provides threaded comment functionality for Symfony 3 applications",
     "keywords": ["comment", "threads", "forum"],

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,14 @@
 {
-    "name": "friendsofsymfony/comment-bundle",
+    "name": "flavienaudin/comment-bundle",
     "type": "symfony-bundle",
-    "description": "This Bundle provides threaded comment functionality for Symfony2 applications",
+    "description": "This Bundle provides threaded comment functionality for Symfony 3 applications",
     "keywords": ["comment", "threads", "forum"],
     "homepage": "http://friendsofsymfony.github.com",
     "license": "MIT",
     "authors": [
+        {
+            "name": "Flavien Audin"
+        },
         {
             "name": "Tim Nagel",
             "email": "tim@nagel.com.au"


### PR DESCRIPTION
Hi,
I detected an exception thrown when I have two "threads" on a page
"Serialization of 'Closure' is not allowed" in the file FormDataCollector of Symfony, when it's tryiing to generate the dev Profiler of Symfony.
I implemented a fix by adding a suffix on form name, when creating a form. I would like to share it and also get your opinion about the possibility of having two or more threads in a page. 
