### PR TITLE
Validates the composer metadata on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,6 @@ install:
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi
     - composer update --no-interaction $COMPOSER_FLAGS
 
-script: phpunit --coverage-text --colors
+script:
+    - composer validate --no-check-lock --strict
+    - phpunit --coverage-text --colors

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     },
     "suggest": {
         "friendsofsymfony/user-bundle": "Allows for user integration.",
-        "ornicar/akismet-bundle": "Integrate Akismet for spamdetection."
+        "ornicar/akismet-bundle": "Integrate Akismet for spam detection."
     },
     "conflict": {
         "twig/twig": "<1.28"


### PR DESCRIPTION
This adds the validation of the composer.json on Travis to forbid merging a PR breaking the metadata (and so breaking the packagist update).