### PR TITLE
Remove deprecated usage of scope attribute

### DIFF
--- a/Resources/config/spam_detection.xml
+++ b/Resources/config/spam_detection.xml
@@ -15,11 +15,11 @@
 
     <services>
 
-        <service id="fos_comment.spam_detection.comment.akismet" class="FOS\CommentBundle\SpamDetection\AkismetSpamDetection" scope="request" public="false">
+        <service id="fos_comment.spam_detection.comment.akismet" class="FOS\CommentBundle\SpamDetection\AkismetSpamDetection" public="false">
             <argument type="service" id="ornicar_akismet" />
         </service>
 
-        <service id="fos_comment.listener.comment_spam" class="FOS\CommentBundle\EventListener\CommentSpamListener" scope="request">
+        <service id="fos_comment.listener.comment_spam" class="FOS\CommentBundle\EventListener\CommentSpamListener">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="fos_comment.spam_detection.comment" />
         </service>


### PR DESCRIPTION
Fixes these deprecation messages / incompatibilities with symfony 3.0:
- The "scope" attribute of service "fos_comment.spam_detection.comment.akismet" in file "FOS/CommentBundle/Resources/config/spam_detection.xml" is deprecated since version 2.8 and will be removed in 3.0
- The "scope" attribute of service "fos_comment.listener.comment_spam" in file "FOS/CommentBundle/Resources/config/spam_detection.xml" is deprecated since version 2.8 and will be removed in 3.0