### PR TITLE
Remove duplicate form elements

### DIFF
--- a/Resources/views/Thread/comment_remove.html.twig
+++ b/Resources/views/Thread/comment_remove.html.twig
@@ -18,8 +18,6 @@
             {{ form_rest(form) }}
         {% endblock %}
 
-        <input type="hidden" name="_method" value="patch" />
-
         <div class="fos_comment_submit">
             {% block fos_comment_form_submit %}
                 <input type="submit" value="{{ 'fos_comment_comment_delete' | trans({}, 'FOSCommentBundle') }}" />

--- a/Resources/views/Thread/commentable.html.twig
+++ b/Resources/views/Thread/commentable.html.twig
@@ -21,8 +21,6 @@
             {{ form_rest(form) }}
         {% endblock %}
 
-        <input type="hidden" name="_method" value="patch" />
-
         <div class="fos_comment_submit">
             {% block fos_comment_form_submit %}
                 <input type="submit" value="{{ (isCommentable ? 'fos_comment_thread_open' : 'fos_comment_thread_close') | trans({}, 'FOSCommentBundle') }}" />


### PR DESCRIPTION
Some forms have the _method element rendered twice in the template, which causes an issue with Symfony 3.3.

```html
<form>
    <input type="hidden" name="_method" value="PATCH" />

    <input type="hidden" name="_method" value="patch" />
</form>
```

The method is already defined in the form factories and rendered by `form_rest`.