### PR TITLE
Throw 404 if fos_comment_get_threads is called without parameters

### DIFF
--- a/Controller/ThreadController.php
+++ b/Controller/ThreadController.php
@@ -86,6 +86,10 @@ class ThreadController extends Controller
     {
         $ids = $request->query->get('ids');
 
+        if (null === $ids) {
+            throw new NotFoundHttpException('Cannot query threads without id\'s.');
+        }
+
         $threads = $this->container->get('fos_comment.manager.thread')->findThreadsBy(array('id' => $ids));
 
         $view = View::create()

--- a/Tests/Functional/ApiTest.php
+++ b/Tests/Functional/ApiTest.php
@@ -46,6 +46,19 @@ class ApiTest extends WebTestCase
     }
 
     /**
+     * Tests retrieval of a threads without id's.
+     *
+     * fos_comment_get_threads: GET: /comment_api/threads
+     */
+    public function testGetThreads404()
+    {
+        $this->client->insulate(true);
+
+        $this->client->request('GET', '/comment_api/threads');
+        $this->assertEquals(404, $this->client->getResponse()->getStatusCode());
+    }
+
+    /**
      * Tests creation of a new form.retrieval of a thread that doesnt exist.
      *
      * fos_comment_new_threads: GET: /comment_api/threads/new.{_format}


### PR DESCRIPTION
Right now calling `/api/threads` without parameters throws an error 500.