### PR TITLE
Comment edit form: form_rest twig function instead of hardcoded token field name

### DIFF
--- a/Controller/ThreadController.php
+++ b/Controller/ThreadController.php
@@ -330,7 +330,7 @@ class ThreadController extends Controller
             throw new NotFoundHttpException(sprintf("No comment with id '%s' found for thread with id '%s'", $commentId, $id));
         }
 
-        $form = $this->container->get('fos_comment.form_factory.comment')->createForm();
+        $form = $this->container->get('fos_comment.form_factory.comment')->createForm(null, array('method' => 'PUT'));
         $form->setData($comment);
 
         $view = View::create()

--- a/Resources/views/Thread/comment_edit.html.twig
+++ b/Resources/views/Thread/comment_edit.html.twig
@@ -16,7 +16,7 @@
             {{ form_errors(form) }}
             {{ form_errors(form.body) }}
             {{ form_widget(form.body) }}
-            {{ form_widget(form._token) }}
+            {{ form_rest(form) }}
         {% endblock %}
 
         <div class="fos_comment_submit">
@@ -25,8 +25,6 @@
                 <input type="submit" value="{% trans from 'FOSCommentBundle' %}fos_comment_comment_edit_submit{% endtrans %}" />
             {% endblock %}
         </div>
-
-        <input type="hidden" name="_method" value="PUT">
 
     </form>
 </div>


### PR DESCRIPTION
I want use the FOSCommentBundle with a eZ Platform installation.

There it is a different token field name.
https://github.com/ezsystems/ezplatform/blob/master/app/config/config.yml#L66

In all other forms the token is set with the form_rest function.
So it would be nice to change it here also.