### PR TITLE
PHP7 - Int annotation class is a reserved class name

### DIFF
--- a/Resources/doc/12b-mapping_mongodb.md
+++ b/Resources/doc/12b-mapping_mongodb.md
@@ -54,7 +54,7 @@ class Comment extends BaseComment implements VotableCommentInterface
     // .. fields
 
     /**
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      * @var int
      */
     protected $score = 0;


### PR DESCRIPTION
PHP7 - Int annotation class is a reserved class name

more details here: https://github.com/doctrine/mongodb-odm/issues/1459#issuecomment-233923219