### PR TITLE
Reply on new comment removes create form

### DIFF
--- a/Resources/public/js/comments.js
+++ b/Resources/public/js/comments.js
@@ -139,7 +139,7 @@
                             FOS_COMMENT.appendComment(data, that);
                             that.trigger('fos_comment_new_comment', data);
                             if (that.data() && that.data().parent !== '') {
-                                that.parents('.fos_comment_comment_form_holder').remove();
+                                that.closest('.fos_comment_comment_form_holder').remove();
                             }
                         },
                         // error


### PR DESCRIPTION
When you create a new comment and reply immediately the create form with the new comment will be removed.