### PR TITLE
Allows flat view for async thread

### DIFF
--- a/Resources/public/js/comments.js
+++ b/Resources/public/js/comments.js
@@ -99,6 +99,10 @@
                 permalink: encodeURIComponent(permalink || window.location.href)
             };
 
+            if (typeof window.fos_comment_thread_view !== 'undefined') {
+                event.params.view = window.fos_comment_thread_view;
+            }
+
             FOS_COMMENT.thread_container.trigger(event);
             FOS_COMMENT.get(
                 FOS_COMMENT.base_url  + '/' + encodeURIComponent(event.identifier) + '/comments',

--- a/Resources/views/Thread/async.html.twig
+++ b/Resources/views/Thread/async.html.twig
@@ -14,6 +14,7 @@
 <script type="text/javascript">
     // thread id
     var fos_comment_thread_id = '{{ id }}';
+    var fos_comment_thread_view = '{{ view|default('tree') }}';
 
     // api base url to use for initial requests
     var fos_comment_thread_api_base_url = '{{ path('fos_comment_get_threads') }}';


### PR DESCRIPTION
Make it possible to set the flat view for async threads with this:
`{% include 'FOSCommentBundle:Thread:async.html.twig' with {'id': contentId, 'view': 'flat'} %}`