### PR TITLE
Fix #638: URL Validator should not be runned against decoded permalink

### DIFF
--- a/Controller/ThreadController.php
+++ b/Controller/ThreadController.php
@@ -392,8 +392,7 @@ class ThreadController extends Controller
 
         // We're now sure it is no duplicate id, so create the thread
         if (null === $thread) {
-            // Decode the permalink for cleaner storage (it is encoded on the client side)
-            $permalink = urldecode($request->query->get('permalink'));
+            $permalink = $request->query->get('permalink');
 
             $thread = $this->container->get('fos_comment.manager.thread')
                 ->createThread();
@@ -415,6 +414,10 @@ class ThreadController extends Controller
 
                 return $this->getViewHandler()->handle($view);
             }
+
+            // Decode the permalink for cleaner storage (it is encoded on the client side)
+            $permalink = urldecode($request->query->get('permalink'));
+            $thread->setPermalink($permalink);
 
             // Add the thread
             $this->container->get('fos_comment.manager.thread')->saveThread($thread);

--- a/Resources/public/js/comments.js
+++ b/Resources/public/js/comments.js
@@ -96,7 +96,7 @@
 
             event.identifier = identifier;
             event.params = {
-                permalink: encodeURIComponent(permalink || window.location.href)
+                permalink: encodeURI(permalink || window.location.href)
             };
 
             if (typeof window.fos_comment_thread_view !== 'undefined') {


### PR DESCRIPTION
See issue https://github.com/FriendsOfSymfony/FOSCommentBundle/issues/638