### PR TITLE
Fix invalid yaml in translations

### DIFF
--- a/Resources/translations/FOSCommentBundle.ja.yml
+++ b/Resources/translations/FOSCommentBundle.ja.yml
@@ -6,7 +6,7 @@ fos_comment_comment_new_cancel:               キャンセル
 fos_comment_comment_edit_submit:              投稿
 fos_comment_comment_edit_cancel:              キャンセル
 
-fos_comment_comment_reply_reply_to:           %name% に返信
+fos_comment_comment_reply_reply_to:           "%name% に返信"
 fos_comment_comment_reply_cancel:             キャンセル
 
 fos_comment_comment_show_by:                  By

--- a/Resources/translations/FOSCommentBundle.mn.yml
+++ b/Resources/translations/FOSCommentBundle.mn.yml
@@ -6,7 +6,7 @@ fos_comment_comment_new_cancel:               Цуцлах
 fos_comment_comment_edit_submit:              Илгээх
 fos_comment_comment_edit_cancel:              Цуцлах
 
-fos_comment_comment_reply_reply_to:           %name% -д хариу бичих
+fos_comment_comment_reply_reply_to:           "%name% -д хариу бичих"
 fos_comment_comment_reply_cancel:             Цуцлах
 
 fos_comment_comment_show_by:                  ""


### PR DESCRIPTION
I was getting an error that yaml was invalid:

> Error parsing YAML, invalid file "vendor/friendsofsymfony/commentbundle/Resources/translations/FOSCommentBundle.ja.yml"   

adding the quotes fixes it.