### PR TITLE
Remove text/javascript type attribute from script tags

### DIFF
--- a/Resources/doc/10-other_ways_of_adding_comments_to_a_page.md
+++ b/Resources/doc/10-other_ways_of_adding_comments_to_a_page.md
@@ -55,7 +55,7 @@ template:
   <div id="fos_comment_thread"> in the DOM Tree, for example right before </body> tag
 #}
 {% javascripts '@FOSCommentBundle/Resources/public/js/comments.js' %}
-<script type="text/javascript" src="{{ asset_url }}"></script>
+<script src="{{ asset_url }}"></script>
 {% endjavascripts %}
 {% endblock javascript %}
 

--- a/Resources/public/js/comments.js
+++ b/Resources/public/js/comments.js
@@ -16,7 +16,7 @@
  * Then a comment thread can be embedded on any page:
  *
  * <div id="fos_comment_thread">#comments</div>
- * <script type="text/javascript">
+ * <script>
  *     // Set the thread_id if you want comments to be loaded via ajax (url to thread comments api)
  *     var fos_comment_thread_id = 'a_unique_identifier_for_the_thread';
  *     var fos_comment_thread_api_base_url = 'http://example.org/api/threads';
@@ -34,7 +34,6 @@
  *     var fos_comment_script = document.createElement('script');
  *     fos_comment_script.async = true;
  *     fos_comment_script.src = 'http://example.org/path/to/this/file.js';
- *     fos_comment_script.type = 'text/javascript';
  *
  *     (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(fos_comment_script);
  * })();

--- a/Resources/views/Thread/async.html.twig
+++ b/Resources/views/Thread/async.html.twig
@@ -11,7 +11,7 @@
 
 <div id="fos_comment_thread"></div>
 
-<script type="text/javascript">
+<script>
     // thread id
     var fos_comment_thread_id = '{{ id }}';
     var fos_comment_thread_view = '{{ view|default('tree') }}';
@@ -24,7 +24,6 @@
         var fos_comment_script = document.createElement('script');
         fos_comment_script.async = true;
         fos_comment_script.src = '{{ asset('bundles/foscomment/js/comments.js') }}';
-        fos_comment_script.type = 'text/javascript';
 
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(fos_comment_script);
     })();

--- a/Tests/Functional/Bundle/CommentBundle/Resources/views/Comment/async.html.twig
+++ b/Tests/Functional/Bundle/CommentBundle/Resources/views/Comment/async.html.twig
@@ -1,6 +1,6 @@
 {% extends '::base.html.twig' %}
 
 {% block body %}
-<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
 {% include '@FOSComment/Thread/async.html.twig' with { 'id': id } %}
 {% endblock body %}

--- a/Tests/Functional/Bundle/CommentBundle/Resources/views/Comment/inline.html.twig
+++ b/Tests/Functional/Bundle/CommentBundle/Resources/views/Comment/inline.html.twig
@@ -11,8 +11,8 @@
 
 {% block javascript %}
 {% javascripts '@FOSCommentBundle/Resources/assets/js/comments.js' %}
-<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
-<script type="text/javascript" src="{{ asset_url }}">
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+<script src="{{ asset_url }}">
 // URI identifier for the thread comments
 var fos_comment_thread_id = '{{ path('fos_comment_get_thread_comments', {'id': thread.id}) }}';
 </script>


### PR DESCRIPTION
In HTML5, `text/javascript` is the default type. So the type attribute becomes redundant.