### PR TITLE
Fixed failing validator with encoded permalink

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,3 +15,4 @@ Changelog
 * Added flat view for async thread.
 * Removed HTTP class constants in `ThreadController`.
 * Fixed form disappearing when creating a new reply.
+* Fixed failing validator with encoded permalink.

--- a/Controller/ThreadController.php
+++ b/Controller/ThreadController.php
@@ -391,8 +391,7 @@ class ThreadController extends Controller
 
         // We're now sure it is no duplicate id, so create the thread
         if (null === $thread) {
-            // Decode the permalink for cleaner storage (it is encoded on the client side)
-            $permalink = urldecode($request->query->get('permalink'));
+            $permalink = $request->query->get('permalink');
 
             $thread = $this->container->get('fos_comment.manager.thread')
                 ->createThread();
@@ -409,6 +408,9 @@ class ThreadController extends Controller
 
                 return $this->getViewHandler()->handle($view);
             }
+
+            // Decode the permalink for cleaner storage (it is encoded on the client side)
+            $thread->setPermalink(urldecode($permalink));
 
             // Add the thread
             $this->container->get('fos_comment.manager.thread')->saveThread($thread);

--- a/Resources/public/js/comments.js
+++ b/Resources/public/js/comments.js
@@ -95,7 +95,7 @@
 
             event.identifier = identifier;
             event.params = {
-                permalink: encodeURIComponent(permalink || window.location.href)
+                permalink: encodeURI(permalink || window.location.href)
             };
 
             if (typeof window.fos_comment_thread_view !== 'undefined') {


### PR DESCRIPTION
Replaces https://github.com/FriendsOfSymfony/FOSCommentBundle/pull/639