### PR TITLE
Move assetic bundle to suggestions

### DIFF
--- a/Tests/Functional/app/Basic/bundles.php
+++ b/Tests/Functional/app/Basic/bundles.php
@@ -12,7 +12,6 @@
 return array(
     new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
 
-    new Symfony\Bundle\AsseticBundle\AsseticBundle(),
     new Symfony\Bundle\SecurityBundle\SecurityBundle(),
     new Symfony\Bundle\TwigBundle\TwigBundle(),
 

--- a/composer.json
+++ b/composer.json
@@ -44,13 +44,13 @@
     "suggest": {
         "friendsofsymfony/user-bundle": "Allows for user integration.",
         "ornicar/akismet-bundle": "Integrate Akismet for spam detection.",
-        "symfony/acl-bundle": "Integrates the ACL Security component."
+        "symfony/acl-bundle": "Integrates the ACL Security component.",
+        "symfony/assetic-bundle": "Integrates Assetic into Symfony."
     },
     "conflict": {
         "twig/twig": "<1.28"
     },
     "require-dev": {
-        "symfony/assetic-bundle": "~2.7",
         "symfony/browser-kit": "~2.7|~3.0|^4.0",
         "symfony/dom-crawler": "~2.7|~3.0|^4.0",
         "symfony/css-selector": "~2.7|~3.0|^4.0",


### PR DESCRIPTION
The assetic bundle prevents the installation of `symfony/http-kernel` 4.1, causing Travis to fail. As assetic is not part of the unit test, I suggest moving the entry to the composer suggestion section.