### PR TITLE
Commands should use the manager aliases

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+### 2.2.1 (2018-xx-xx)
+
+* Fix: commands should use the manager alias.
+
 ### 2.2.0 (2018-06-04)
 
 * Allow template override in Symfony 4.

--- a/Resources/config/commands.xml
+++ b/Resources/config/commands.xml
@@ -17,11 +17,11 @@
         <service id="fos_comment.command.fix_aces" class="FOS\CommentBundle\Command\FixAcesCommand">
             <argument type="service" id="security.acl.provider" />
             <argument type="service" id="fos_comment.acl.comment" />
-            <argument type="service" id="fos_comment.manager.comment.default" />
+            <argument type="service" id="fos_comment.manager.comment" />
             <argument type="service" id="fos_comment.acl.thread" />
-            <argument type="service" id="fos_comment.manager.thread.default" />
+            <argument type="service" id="fos_comment.manager.thread" />
             <argument type="service" id="fos_comment.acl.vote" />
-            <argument type="service" id="fos_comment.manager.vote.default" />
+            <argument type="service" id="fos_comment.manager.vote" />
             <tag name="console.command" command="fos:comment:fixAces" />
         </service>
         <service id="fos_comment.command.install_aces" class="FOS\CommentBundle\Command\InstallAcesCommand">


### PR DESCRIPTION
Right now custom managers cannot be injected in the commands.