### PR TITLE
Use the correct Symfony Controller class based on Symfony version

### DIFF
--- a/Controller/AbstractController.php
+++ b/Controller/AbstractController.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the FOSCommentBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace FOS\CommentBundle\Controller;
+
+/**
+ * Determine which base class to use depending on what version of Symfony is installed.
+ *
+ * Symfony 3.3+ uses AbstractController, while older versions use Controller.
+ */
+if (class_exists('Symfony\Bundle\FrameworkBundle\Controller\AbstractController')) {
+    class AbstractController extends \Symfony\Bundle\FrameworkBundle\Controller\AbstractController
+    {
+    }
+} else {
+    class AbstractController extends \Symfony\Bundle\FrameworkBundle\Controller\Controller
+    {
+    }
+}

--- a/Controller/AbstractController.php
+++ b/Controller/AbstractController.php
@@ -15,13 +15,15 @@ namespace FOS\CommentBundle\Controller;
  * Determine which base class to use depending on what version of Symfony is installed.
  *
  * Symfony 3.3+ uses AbstractController, while older versions use Controller.
+ *
+ * @internal
  */
 if (class_exists('Symfony\Bundle\FrameworkBundle\Controller\AbstractController')) {
-    class AbstractController extends \Symfony\Bundle\FrameworkBundle\Controller\AbstractController
+    abstract class AbstractController extends \Symfony\Bundle\FrameworkBundle\Controller\AbstractController
     {
     }
 } else {
-    class AbstractController extends \Symfony\Bundle\FrameworkBundle\Controller\Controller
+    abstract class AbstractController extends \Symfony\Bundle\FrameworkBundle\Controller\Controller
     {
     }
 }

--- a/Controller/ThreadController.php
+++ b/Controller/ThreadController.php
@@ -14,7 +14,6 @@ namespace FOS\CommentBundle\Controller;
 use FOS\CommentBundle\Model\CommentInterface;
 use FOS\CommentBundle\Model\ThreadInterface;
 use FOS\RestBundle\View\View;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -26,7 +25,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  *
  * @author Alexander <iam.asm89@gmail.com>
  */
-class ThreadController extends Controller
+class ThreadController extends AbstractController
 {
     const VIEW_FLAT = 'flat';
     const VIEW_TREE = 'tree';


### PR DESCRIPTION
Would you consider using the following PR to allow Symfony 4.x and eventually 5.x to maintain compatibility with Symfony 2.8, assuming support is still planned legacy Symfony versions.