### PR TITLE
AclCommentManager::saveComment must have a return value

### DIFF
--- a/Acl/AclCommentManager.php
+++ b/Acl/AclCommentManager.php
@@ -130,11 +130,13 @@ class AclCommentManager implements CommentManagerInterface
             throw new AccessDeniedException();
         }
 
-        $this->realManager->saveComment($comment);
+        $state = $this->realManager->saveComment($comment);
 
-        if ($newComment) {
+        if ($state && $newComment) {
             $this->commentAcl->setDefaultAcl($comment);
         }
+
+        return $state;
     }
 
     /**

--- a/Tests/Acl/AclCommentManagerTest.php
+++ b/Tests/Acl/AclCommentManagerTest.php
@@ -227,6 +227,11 @@ class AclCommentManagerTest extends TestCase
              ->with($this->equalTo($this->comment))
              ->will($this->returnValue(true));
 
+        $this->realManager->expects($this->once())
+             ->method('saveComment')
+             ->with($this->equalTo($this->comment))
+             ->will($this->returnValue(true));
+
         $manager = new AclCommentManager($this->realManager, $this->commentSecurity, $this->threadSecurity);
         $manager->saveComment($this->comment, $this->parent);
     }


### PR DESCRIPTION
Fixes https://github.com/FriendsOfSymfony/FOSCommentBundle/issues/691