### PR TITLE
Commandd::execute must return integer type

### DIFF
--- a/Command/FixAcesCommand.php
+++ b/Command/FixAcesCommand.php
@@ -122,7 +122,7 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $foundThreadAcls = 0;
         $foundCommentAcls = 0;
@@ -172,5 +172,7 @@ EOT
         $output->writeln("Found {$foundThreadAcls} Thread Acl Entries, Created {$createdThreadAcls} Thread Acl Entries");
         $output->writeln("Found {$foundCommentAcls} Comment Acl Entries, Created {$createdCommentAcls} Comment Acl Entries");
         $output->writeln("Found {$foundVoteAcls} Vote Acl Entries, Created {$createdVoteAcls} Vote Acl Entries");
+
+        return 0;
     }
 }

--- a/Command/InstallAcesCommand.php
+++ b/Command/InstallAcesCommand.php
@@ -86,7 +86,7 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if ($input->getOption('flush')) {
             $output->writeln('Flushing Global ACEs');
@@ -101,5 +101,7 @@ EOT
         $this->voteAcl->installFallbackAcl();
 
         $output->writeln('Global ACEs have been installed.');
+
+        return 0;
     }
 }


### PR DESCRIPTION
Since Symfony 4.4