### PR TITLE
Fix Uncaught PHP Exception Symfony\Component\HttpKernel\Exception\Met…

### DIFF
--- a/Resources/public/js/comments.js
+++ b/Resources/public/js/comments.js
@@ -303,10 +303,13 @@
                         function(data) {
                             // Post it
                             var form = $($.trim(data)).children('form')[0];
+                            // Fix wrong _method used with the controler
+                            var serialized_form = FOS_COMMENT.serializeObject(form);
+                            serialized_form._method = 'patch';
 
                             FOS_COMMENT.post(
                                 form.action,
-                                FOS_COMMENT.serializeObject(form),
+                                serialized_form,
                                 function(data) {
                                     var commentHtml = $($.trim(data));
 


### PR DESCRIPTION
…hodNotAllowedHttpException: "No route found for "POST /api/comment/threads/1/comments/1/state": Method Not Allowed (Allow: PATCH)"